### PR TITLE
Fix deliverables lost on RO-Crate round-trip

### DIFF
--- a/src/utils/rocrate.ts
+++ b/src/utils/rocrate.ts
@@ -819,6 +819,7 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
         const outcomeEntity: ROCrateEntity = {
           '@id': outcomeId,
           '@type': deliverable.type ? `schema:${deliverable.type}` : 'schema:CreativeWork',
+          'aac:outcomeType': 'deliverable',
           name: deliverable.title,
           description: deliverable.description,
         }


### PR DESCRIPTION
## Summary

- Deliverables vanished after download and re-upload because the import only matched a hardcoded set of `@type` values (`CreativeWork`, `Report`, `ScholarlyArticle`), while the deliverable type is a free-text field that can be any schema.org type (e.g., `SoftwareApplication`, `Dataset`, `Document`)
- Export now tags deliverable entities with `aac:outcomeType: 'deliverable'` (consistent with the existing `aac:evaluationType` pattern for evaluations)
- Import matches on this marker first, with a legacy fallback to the old type-matching for older crates

## Test plan

- [x] Create a canvas with deliverables of various types (Report, SoftwareApplication, Dataset, custom text)
- [x] Download as RO-Crate
- [x] Re-upload and verify all deliverables appear in the canvas summary and outcomes page
- [x] Test with a crate exported before this fix (legacy format) to verify backward compatibility