### PR TITLE
Fix RO-Crate aac: namespace and emit funding as FRAPO

### DIFF
--- a/schema/examples/complete-example.json
+++ b/schema/examples/complete-example.json
@@ -7,7 +7,7 @@
       "p-plan": "http://purl.org/net/p-plan#",
       "dct": "http://purl.org/dc/terms/",
       "dcat": "http://www.w3.org/ns/dcat#",
-      "aac": "https://github.com/slolab/agentic-automation-canvas/schema/"
+      "aac": "https://w3id.org/aac/schema/"
     }
   ],
   "@graph": [

--- a/schema/mappings/frapo.md
+++ b/schema/mappings/frapo.md
@@ -6,10 +6,12 @@ This document describes how Agentic Automation Canvas fields map to FRAPO (Fundi
 
 ### FRAPO Project Properties
 
-| Canvas Field | FRAPO Property | Type | Description |
+| Canvas Field | FRAPO Term | Type | Description |
 |-------------|----------------|------|-------------|
 | project | `frapo:Project` | Class | Project entity |
-| funding grant | `frapo:fundingGrant` | Grant | Associated grant |
+| funding grant | `frapo:isFundedBy` | Object property | Links the project to its `frapo:Grant` entity |
+| funding grant | `frapo:Grant` | Class | The grant that funds the project |
+| funding grant | `frapo:hasGrantNumber` | Datatype property | Grant number / identifier carried on the `frapo:Grant` |
 | lead organization | `frapo:leadOrganization` | Organization | Lead organization |
 | project status | `frapo:hasStatus` | Status | Project status |
 | start date | `frapo:hasStartDate` | Date | Project start date |
@@ -25,6 +27,24 @@ This document describes how Agentic Automation Canvas fields map to FRAPO (Fundi
 | deliverable | `frapo:deliverable` | Deliverable | Project deliverable |
 | deliverable type | `dct:type` | Literal | Type of deliverable |
 | due date | `dct:date` | Date | Deliverable due date |
+
+### Funding
+
+The exporter maps the canvas `funding grant` field to a dedicated
+`frapo:Grant` entity, linked from the project via `frapo:isFundedBy`:
+
+```json
+{
+  "@type": ["schema:Project", "schema:ResearchProject"],
+  "@id": "#project",
+  "frapo:isFundedBy": { "@id": "#grant" }
+}
+{
+  "@type": "frapo:Grant",
+  "@id": "#grant",
+  "frapo:hasGrantNumber": "ERC-2024-STG-101234567"
+}
+```
 
 ### Example Structure
 

--- a/schema/rocrate-profile.json
+++ b/schema/rocrate-profile.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/slolab/agentic-automation-canvas/schema/rocrate-profile.json",
+  "$id": "https://w3id.org/aac/schema/rocrate-profile.json",
   "title": "RO-Crate Profile for Agentic Automation Canvas",
   "description": "Profile definition for RO-Crate packages generated from Agentic Automation Canvas",
   "type": "object",

--- a/src/utils/import.spec.ts
+++ b/src/utils/import.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseROCrateToCanvas } from '@/utils/import'
+import { generateROCrate } from '@/utils/rocrate'
 import type { ROCrateJSONLD } from '@/types/rocrate'
 
 /** Minimal RO-Crate 1.2: root dataset + one project entity, no requirements. */
@@ -222,5 +223,17 @@ describe('parseROCrateToCanvas', () => {
       currency: 'EUR',
       costNotes: 'GPU instance',
     })
+  })
+
+  it('recovers fundingGrant from a FRAPO Grant entity (export→import roundtrip)', () => {
+    const crate = generateROCrate({
+      project: {
+        title: 'Funded Project',
+        description: 'Desc',
+        fundingGrant: 'ERC-2024-STG-101234567',
+      },
+    })
+    const canvasData = parseROCrateToCanvas(crate)
+    expect(canvasData.project.fundingGrant).toBe('ERC-2024-STG-101234567')
   })
 })

--- a/src/utils/import.ts
+++ b/src/utils/import.ts
@@ -42,6 +42,11 @@ export function parseROCrateToCanvas(rocrate: ROCrateJSONLD): CanvasData {
   // Find project entity
   const projectEntity = findEntitiesByType(graph, ['Project', 'ResearchProject', 'schema:Project', 'schema:ResearchProject'])[0]
   if (projectEntity) {
+    // Funding (FRAPO): the grant number lives on the frapo:Grant entity
+    // referenced by frapo:isFundedBy.
+    const fundingRef = projectEntity['frapo:isFundedBy'] as { '@id': string } | undefined
+    const grantEntity = fundingRef?.['@id'] ? findEntity(graph, fundingRef['@id']) : undefined
+    const fundingGrant = (grantEntity?.['frapo:hasGrantNumber'] as string) || undefined
     canvasData.project = {
       title: (projectEntity.name as string) || '',
       description: (projectEntity.description as string) || '',
@@ -64,6 +69,7 @@ export function parseROCrateToCanvas(rocrate: ROCrateJSONLD): CanvasData {
           ? [projectEntity.keywords as string]
           : undefined,
       projectId: (projectEntity.identifier as string) || undefined,
+      fundingGrant,
       headlineValue: (projectEntity['aac:headlineValue'] as string) || undefined,
       primaryValueDriver: (projectEntity['aac:primaryValueDriver'] as 'time' | 'quality' | 'risk' | 'enablement') || undefined,
       roughEstimateValue: (projectEntity['aac:roughEstimateValue'] as number) ?? undefined,

--- a/src/utils/rocrate.spec.ts
+++ b/src/utils/rocrate.spec.ts
@@ -236,4 +236,50 @@ describe('generateROCrate', () => {
       costNotes: 'GPT-4o pricing',
     })
   })
+
+  it('@context maps aac: to the persistent w3id.org namespace', () => {
+    const out = generateROCrate(minimalCanvasData)
+    const contextObj = (out['@context'] as Array<unknown>).find(
+      (c): c is Record<string, string> => typeof c === 'object' && c !== null,
+    ) as Record<string, string>
+    expect(contextObj.aac).toBe('https://w3id.org/aac/schema/')
+  })
+
+  it('emits fundingGrant as a FRAPO Grant entity linked via frapo:isFundedBy', () => {
+    const data: CanvasData = {
+      project: {
+        title: 'Funded Project',
+        description: '',
+        fundingGrant: 'ERC-2024-STG-101234567',
+      },
+    }
+    const out = generateROCrate(data)
+    // frapo namespace registered in @context
+    const contextObj = (out['@context'] as Array<unknown>).find(
+      (c): c is Record<string, string> => typeof c === 'object' && c !== null,
+    ) as Record<string, string>
+    expect(contextObj.frapo).toBe('http://purl.org/cerif/frapo/')
+    // project references the grant
+    const project = out['@graph'].find(
+      (e: { '@id': string }) => e['@id'] === '#project',
+    ) as Record<string, unknown>
+    const grantRef = project['frapo:isFundedBy'] as { '@id': string }
+    expect(grantRef).toBeDefined()
+    // grant entity carries the grant number
+    const grant = out['@graph'].find(
+      (e: { '@id': string }) => e['@id'] === grantRef['@id'],
+    ) as Record<string, unknown>
+    expect(grant['@type']).toBe('frapo:Grant')
+    expect(grant['frapo:hasGrantNumber']).toBe('ERC-2024-STG-101234567')
+  })
+
+  it('does not emit a Grant entity when fundingGrant is absent', () => {
+    const out = generateROCrate(minimalCanvasData)
+    const grant = out['@graph'].find((e: { '@type'?: unknown }) => e['@type'] === 'frapo:Grant')
+    expect(grant).toBeUndefined()
+    const project = out['@graph'].find(
+      (e: { '@id': string }) => e['@id'] === '#project',
+    ) as Record<string, unknown>
+    expect(project['frapo:isFundedBy']).toBeUndefined()
+  })
 })

--- a/src/utils/rocrate.ts
+++ b/src/utils/rocrate.ts
@@ -458,6 +458,12 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
   if (data.project.projectId) {
     projectEntity.identifier = data.project.projectId
   }
+  // Funding (FRAPO): link the project to a Grant entity so funding is
+  // expressed in FRAPO terms rather than as a bare string.
+  const grantId = generateId('grant')
+  if (data.project.fundingGrant) {
+    projectEntity['frapo:isFundedBy'] = { '@id': grantId }
+  }
   // Project-level value summary
   if (data.project.headlineValue) {
     projectEntity['aac:headlineValue'] = data.project.headlineValue
@@ -484,6 +490,15 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
   }
 
   graph.push(projectEntity)
+
+  // Grant entity (FRAPO) — carries the funding grant number
+  if (data.project.fundingGrant) {
+    graph.push({
+      '@id': grantId,
+      '@type': 'frapo:Grant',
+      'frapo:hasGrantNumber': data.project.fundingGrant,
+    })
+  }
 
   // Initialize Person registry for deduplication
   // Map canvas personId to RO-Crate personId
@@ -1018,6 +1033,7 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
       'p-plan': 'http://purl.org/net/p-plan#',
       dct: 'http://purl.org/dc/terms/',
       dcat: 'http://www.w3.org/ns/dcat#',
+      frapo: 'http://purl.org/cerif/frapo/',
       aac: 'https://w3id.org/aac/schema/',
     },
   ]

--- a/src/utils/rocrate.ts
+++ b/src/utils/rocrate.ts
@@ -1018,7 +1018,7 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
       'p-plan': 'http://purl.org/net/p-plan#',
       dct: 'http://purl.org/dc/terms/',
       dcat: 'http://www.w3.org/ns/dcat#',
-      aac: 'https://github.com/slolab/agentic-automation-canvas/schema/',
+      aac: 'https://w3id.org/aac/schema/',
     },
   ]
 


### PR DESCRIPTION
Two small fixes to the RO-Crate export.

- First, the exporter was writing the aac: namespace as a github.com/slolab URL, which is a non-persistent identifier and disagreed with our own published spec at w3id.org/aac.
- Second, we advertise FRAPO support and the schema has a fundingGrant field, but nothing was actually written in FRAPO terms on export.