### PR TITLE
feat: essentials-first canvas summary and task-level data access

### DIFF
--- a/schema/canvas-schema.json
+++ b/schema/canvas-schema.json
@@ -116,6 +116,29 @@
                 "type": "string",
                 "description": "The user population whose benefit estimates this task captures (e.g., 'junior researchers', 'clinical staff with 3+ years experience'). Specifying this makes heterogeneity explicit when different user groups are expected to benefit differently from the same type of task."
               },
+              "dataAccess": {
+                "type": "object",
+                "description": "Task-level data access: which datasets this task uses and what the agent may do with them. Datasets remain defined once in dataAccess.datasets; tasks reference them by id (edited from the Data Access tab).",
+                "properties": {
+                  "datasetLinks": {
+                    "type": "array",
+                    "description": "Links to datasets this task uses, with agent permissions",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "datasetId": { "type": "string", "description": "Id of a dataset defined in dataAccess.datasets" },
+                        "agentActions": {
+                          "type": "array",
+                          "description": "What the agent is allowed to do with this dataset",
+                          "items": { "type": "string", "enum": ["read", "modify", "process", "generate"] }
+                        },
+                        "notes": { "type": "string", "description": "Free-text notes on this task-dataset link" }
+                      },
+                      "required": ["datasetId"]
+                    }
+                  }
+                }
+              },
               "feasibility": {
                 "type": "object",
                 "description": "Optional per-task feasibility (overrides project-level defaults)",

--- a/schema/examples/complete-canvas.json
+++ b/schema/examples/complete-canvas.json
@@ -103,6 +103,15 @@
             "currency": "USD",
             "costNotes": "Based on Claude API pricing at ~1.5K tokens/interaction"
           }
+        },
+        "dataAccess": {
+          "datasetLinks": [
+            {
+              "datasetId": "dataset-0",
+              "agentActions": ["read", "process"],
+              "notes": "Restricted dataset processed by a frontier model — data-processing agreement with the model provider required."
+            }
+          ]
         }
       }
     ]

--- a/schema/examples/complete-example.json
+++ b/schema/examples/complete-example.json
@@ -119,7 +119,17 @@
           "currency": "USD",
           "costNotes": "Based on Claude API pricing at ~1.5K tokens/interaction"
         }
-      }
+      },
+      "aac:dataAccess": {
+        "datasetLinks": [
+          {
+            "datasetId": "dataset-0",
+            "agentActions": ["read", "process"],
+            "notes": "Restricted dataset processed by a frontier model — data-processing agreement with the model provider required."
+          }
+        ]
+      },
+      "prov:used": { "@id": "#dataset-0" }
     },
     {
       "@id": "#stage-0",

--- a/schema/mappings/prov-o.md
+++ b/schema/mappings/prov-o.md
@@ -34,6 +34,35 @@ User expectations are represented as `prov:Plan` entities using P-Plan extension
 }
 ```
 
+## Task-Level Data Access
+
+Tasks declare which datasets they use and what the agent may do with them. Links
+are exported both as a machine-readable blob (`aac:dataAccess`) and as PROV
+usage relations from the step to the referenced `dcat:Dataset` entities:
+
+| Canvas Field | Property | Type | Description |
+|-------------|----------------|------|-------------|
+| task ↔ dataset link | `prov:used` | Entity | Step references each linked dataset (and the model card, if set) |
+| dataset links + agent actions | `aac:dataAccess` | Blob | `datasetLinks[]` with `datasetId`, `agentActions` (read / modify / process / generate), `notes` |
+
+### Example Structure
+
+```json
+{
+  "@id": "#task-deid",
+  "@type": "p-plan:Step",
+  "prov:used": { "@id": "#ds-letters" },
+  "aac:dataAccess": {
+    "datasetLinks": [
+      { "datasetId": "ds-letters", "agentActions": ["read", "process", "generate"] }
+    ]
+  }
+}
+```
+
+Dataset crate `@id`s preserve the canvas dataset id, so task-level links remain
+resolvable after export → import roundtrips.
+
 ## Governance & Staging
 
 Governance stages are represented as `prov:Activity` entities:

--- a/schema/mappings/prov-o.md
+++ b/schema/mappings/prov-o.md
@@ -60,8 +60,10 @@ usage relations from the step to the referenced `dcat:Dataset` entities:
 }
 ```
 
-Dataset crate `@id`s preserve the canvas dataset id, so task-level links remain
-resolvable after export → import roundtrips.
+Dataset crate `@id`s preserve the canvas dataset id where it forms a valid,
+unique fragment; other datasets get a unique `#dataset-<n>` id, and the blob's
+`datasetId`s are rewritten to match the emitted `@id`s. Either way, task-level
+links remain resolvable after export → import roundtrips.
 
 ## Governance & Staging
 

--- a/src/components/sections/CanvasSummary.vue
+++ b/src/components/sections/CanvasSummary.vue
@@ -95,11 +95,16 @@
                   @input="updateProject({ headlineValue: ($event.target as HTMLInputElement).value })"
                 />
               </div>
-              <template v-if="!showProjectStrip">
+              <div
+                v-if="!isEmptyProject(summary.project)"
+                class="space-y-1.5"
+                :class="{ 'canvas-fw-print-only': showProjectStrip }"
+              >
                 <p class="font-semibold">{{ summary.project.title }}</p>
                 <p v-if="summary.project.description" class="text-gray-600">{{ summary.project.description }}</p>
                 <p v-if="summary.project.headlineValue" class="font-medium">{{ summary.project.headlineValue }}</p>
-              </template>
+              </div>
+              <p v-else class="italic text-gray-400" :class="{ 'canvas-fw-print-only': showProjectStrip }">Not specified</p>
               <p v-if="summary.project.stage" class="text-xs uppercase">{{ summary.project.stage }}</p>
               <p v-if="summary.project.primaryValueDriver" class="text-xs">Primary value: {{ summary.project.primaryValueDriver }}</p>
               <div v-if="summary.project.domain.length" class="flex flex-wrap gap-1 text-xs">
@@ -174,12 +179,16 @@
                   @input="patchFirstTask({ targetPopulation: ($event.target as HTMLInputElement).value })"
                 />
               </div>
-              <p><strong>{{ summary.userExpectations.taskCount }}</strong> tasks</p>
-              <div v-if="visibleTasks.length" class="space-y-2">
+              <p v-if="summary.userExpectations.taskCount > 0">
+                <strong>{{ summary.userExpectations.taskCount }}</strong>
+                {{ summary.userExpectations.taskCount === 1 ? 'task' : 'tasks' }}
+              </p>
+              <div v-if="summary.userExpectations.tasks.length" class="space-y-2">
                 <div
-                  v-for="(t, i) in visibleTasks"
+                  v-for="(t, i) in summary.userExpectations.tasks"
                   :key="i"
                   class="border-l-2 border-gray-300 pl-2 py-0.5"
+                  :class="{ 'canvas-fw-print-only': showTasksStrip && i === 0 }"
                 >
                   <p class="font-medium text-gray-900">{{ t.title }}</p>
                   <p v-if="t.userStory" class="text-xs italic mt-0.5 user-story-text">
@@ -211,7 +220,11 @@
                   </button>
                 </div>
               </template>
-              <p v-if="isEmptyUserExpectations(summary.userExpectations) && !showTasksStrip" class="italic text-gray-400">Not specified</p>
+              <p
+                v-if="isEmptyUserExpectations(summary.userExpectations)"
+                class="italic text-gray-400"
+                :class="{ 'canvas-fw-print-only': showTasksStrip }"
+              >Not specified</p>
             </div>
           </div>
           <div class="canvas-bmc-block flex-[1] px-4 pt-2 pb-4">
@@ -261,7 +274,7 @@
                   <span v-for="s in summary.dataAccess.sensitivitySummary" :key="s" class="text-gray-600">{{ s }}</span>
                 </div>
               </template>
-              <p v-else-if="!showDataAccessStrip" class="italic text-gray-400">Not specified</p>
+              <p v-else class="italic text-gray-400" :class="{ 'canvas-fw-print-only': showDataAccessStrip }">Not specified</p>
             </div>
           </div>
         </div>
@@ -308,7 +321,7 @@
                 </span>
                 <span v-else-if="summary.developerFeasibility.trlTarget !== null">target {{ summary.developerFeasibility.trlTarget }}</span>
               </div>
-              <p v-if="summary.developerFeasibility.technicalRisk && !showFeasibilityStrip">Risk: <span class="capitalize">{{ summary.developerFeasibility.technicalRisk }}</span></p>
+              <p v-if="summary.developerFeasibility.technicalRisk" :class="{ 'canvas-fw-print-only': showFeasibilityStrip }">Risk: <span class="capitalize">{{ summary.developerFeasibility.technicalRisk }}</span></p>
               <p v-if="summary.developerFeasibility.effortEstimate">Effort: {{ summary.developerFeasibility.effortEstimate }}</p>
               <p v-if="summary.developerFeasibility.amortizationMonths !== null" class="text-xs">
                 ~{{ summary.developerFeasibility.amortizationMonths!.toFixed(1) }} mo until amortization
@@ -328,7 +341,11 @@
                   />
                 </div>
               </div>
-              <p v-if="isEmptyDeveloperFeasibility(summary.developerFeasibility) && summary.userExpectations.taskCount === 0 && !showFeasibilityStrip" class="italic text-gray-400">Not specified</p>
+              <p
+                v-if="isEmptyDeveloperFeasibility(summary.developerFeasibility) && summary.userExpectations.taskCount === 0"
+                class="italic text-gray-400"
+                :class="{ 'canvas-fw-print-only': showFeasibilityStrip }"
+              >Not specified</p>
             </div>
           </div>
           <div class="canvas-bmc-block flex-1 px-4 pt-2 pb-4">
@@ -368,12 +385,16 @@
                 />
               </div>
               <template v-if="!isEmptyOutcomes(summary.outcomes)">
-                <template v-if="visibleDeliverables.length">
+                <template v-if="summary.outcomes.deliverables.length">
                   <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">
                     {{ summary.outcomes.deliverableCount }} {{ summary.outcomes.deliverableCount === 1 ? 'deliverable' : 'deliverables' }}
                   </p>
                   <ul class="list-none space-y-0.5 text-xs">
-                    <li v-for="(d, i) in visibleDeliverables" :key="'d-' + i">
+                    <li
+                      v-for="(d, i) in summary.outcomes.deliverables"
+                      :key="'d-' + i"
+                      :class="{ 'canvas-fw-print-only': showOutcomesStrip && i === 0 }"
+                    >
                       <a
                         v-if="isLink(d.pid)"
                         :href="d.pid!"
@@ -414,7 +435,7 @@
                   </ul>
                 </template>
               </template>
-              <p v-else-if="!showOutcomesStrip" class="italic text-gray-400">Not specified</p>
+              <p v-else class="italic text-gray-400" :class="{ 'canvas-fw-print-only': showOutcomesStrip }">Not specified</p>
             </div>
           </div>
         </div>
@@ -511,14 +532,6 @@ const firstTask = computed<Requirement | undefined>(() => canvasData.value.userE
 const firstDataset = computed<Dataset | undefined>(() => canvasData.value.dataAccess?.datasets?.[0])
 const firstDeliverable = computed<Deliverable | undefined>(() => canvasData.value.outcomes?.deliverables?.[0])
 
-// Hide the first item from the rendered lists while its strip edits it (avoids double display)
-const visibleTasks = computed(() =>
-  showTasksStrip.value ? summary.value.userExpectations.tasks.slice(1) : summary.value.userExpectations.tasks
-)
-const visibleDeliverables = computed(() =>
-  showOutcomesStrip.value ? summary.value.outcomes.deliverables.slice(1) : summary.value.outcomes.deliverables
-)
-
 function patchFirstTask(patch: Partial<Requirement>) {
   const requirements = canvasData.value.userExpectations?.requirements || []
   if (requirements.length === 0) {
@@ -580,6 +593,11 @@ function formatDeploymentCostSummary(totals: Record<string, number>): string {
   const entries = Object.entries(totals).filter(([, amount]) => amount > 0)
   if (entries.length === 0) return ''
   return entries.map(([currency, amount]) => formatDeploymentCost(amount, currency)).join(' + ')
+}
+
+function isEmptyProject(p: CanvasSummaryData['project']): boolean {
+  const noTitle = !p.title || p.title === 'Untitled Project'
+  return noTitle && !p.description && !p.stage && !p.headlineValue && !p.primaryValueDriver && p.domain.length === 0
 }
 
 function isEmptyUserExpectations(u: CanvasSummaryData['userExpectations']): boolean {
@@ -773,10 +791,19 @@ function isEmptyOutcomes(o: CanvasSummaryData['outcomes']): boolean {
   box-shadow: 0 0 0 1px rgb(14 165 233 / 0.3);
 }
 
+/* Content a strip is currently editing is hidden on screen (avoids double
+   display) but must reappear in print, where the strips themselves are hidden */
+.canvas-fw-print-only {
+  display: none;
+}
+
 @media print {
   .canvas-fw-chip,
   .canvas-fw-strip {
     display: none;
+  }
+  .canvas-fw-print-only {
+    display: revert;
   }
 }
 

--- a/src/components/sections/CanvasSummary.vue
+++ b/src/components/sections/CanvasSummary.vue
@@ -9,8 +9,30 @@
         />
       </h2>
       <p class="section-description">
-        A single-page summary of your agentic automation project. Fill in the other sections to populate this overview.
+        A single-page summary of your agentic automation project. Start with the six essentials right here — the full detail lives in the other sections.
       </p>
+    </div>
+
+    <!-- Essentials guidance: start simple, go deeper when ready -->
+    <div
+      v-if="fwProgress.completeCount < 6"
+      class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary-200 bg-primary-50 px-4 py-3"
+      style="max-width: 1100px"
+    >
+      <p class="text-sm text-primary-900 m-0">
+        <strong>Start simple:</strong> fill in the essentials below. Click a block title to open the full section when you're ready.
+      </p>
+      <span class="text-sm font-semibold text-primary-700 whitespace-nowrap">{{ fwProgress.completeCount }}/6 essentials</span>
+    </div>
+    <div
+      v-else
+      class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-2.5 text-sm text-green-800"
+      style="max-width: 1100px"
+    >
+      <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+      </svg>
+      Essentials complete — click a block title to fill in the remaining fields.
     </div>
 
     <!-- Classic BMC-style canvas: white bg, thin grey grid, minimal layout -->
@@ -29,30 +51,68 @@
         <!-- Left column: 1/2 + 1/2 -->
         <div class="canvas-bmc-col flex flex-col border-r-2 border-black">
           <div class="canvas-bmc-block flex-1 border-b-2 border-black px-4 pt-2 pb-4">
-            <h4 class="canvas-bmc-block-title flex items-center gap-2 text-gray-900">
+            <h4 class="canvas-bmc-block-title flex flex-wrap items-center gap-2 text-gray-900">
               <button type="button" class="canvas-bmc-block-title-link" @click="requestSection('project')">
                 Project Definition
-                <CanvasBlockIcon name="project" class="ml-auto" />
               </button>
+              <button
+                type="button"
+                class="canvas-fw-chip"
+                :class="{ 'canvas-fw-chip--done': fwProgress.summary && fwProgress.benefit }"
+                @click="toggleFwEdit('project')"
+              >
+                <template v-if="fwProgress.summary && fwProgress.benefit">essentials ✓</template>
+                <template v-else>essentials {{ (fwProgress.summary ? 1 : 0) + (fwProgress.benefit ? 1 : 0) }}/2</template>
+              </button>
+              <CanvasBlockIcon name="project" />
             </h4>
             <div class="canvas-bmc-content text-sm text-gray-800 space-y-1.5">
-              <p class="font-semibold">{{ summary.project.title }}</p>
-              <p v-if="summary.project.description" class="text-gray-600">{{ summary.project.description }}</p>
+              <div v-if="showProjectStrip" class="canvas-fw-strip" @focusout="onStripFocusOut('project', $event)">
+                <label class="canvas-fw-label" for="fw-project-title">Summary — what is this project?</label>
+                <input
+                  id="fw-project-title"
+                  class="canvas-fw-input font-semibold"
+                  type="text"
+                  placeholder="Project title"
+                  :value="canvasData.project.title"
+                  @input="updateProject({ title: ($event.target as HTMLInputElement).value })"
+                />
+                <textarea
+                  id="fw-project-description"
+                  class="canvas-fw-input"
+                  rows="2"
+                  placeholder="One or two sentences on what it does and for whom"
+                  :value="canvasData.project.description"
+                  @input="updateProject({ description: ($event.target as HTMLTextAreaElement).value })"
+                ></textarea>
+                <label class="canvas-fw-label" for="fw-project-benefit">Headline value — what do you hope to gain?</label>
+                <input
+                  id="fw-project-benefit"
+                  class="canvas-fw-input"
+                  type="text"
+                  placeholder="e.g. Saves clinician time on letter triage"
+                  :value="canvasData.project.headlineValue || ''"
+                  @input="updateProject({ headlineValue: ($event.target as HTMLInputElement).value })"
+                />
+              </div>
+              <template v-if="!showProjectStrip">
+                <p class="font-semibold">{{ summary.project.title }}</p>
+                <p v-if="summary.project.description" class="text-gray-600">{{ summary.project.description }}</p>
+                <p v-if="summary.project.headlineValue" class="font-medium">{{ summary.project.headlineValue }}</p>
+              </template>
               <p v-if="summary.project.stage" class="text-xs uppercase">{{ summary.project.stage }}</p>
-              <p v-if="summary.project.headlineValue" class="font-medium">{{ summary.project.headlineValue }}</p>
               <p v-if="summary.project.primaryValueDriver" class="text-xs">Primary value: {{ summary.project.primaryValueDriver }}</p>
               <div v-if="summary.project.domain.length" class="flex flex-wrap gap-1 text-xs">
                 <span v-for="d in summary.project.domain" :key="d" class="text-gray-600">{{ d }}</span>
               </div>
-              <p v-if="isEmptyProject(summary.project)" class="italic text-gray-400">Not specified</p>
             </div>
           </div>
           <div class="canvas-bmc-block flex-1 px-4 pt-2 pb-4">
             <h4 class="canvas-bmc-block-title flex items-center gap-2 text-gray-900">
               <button type="button" class="canvas-bmc-block-title-link" @click="requestSection('governance')">
                 Governance
-                <CanvasBlockIcon name="governance" class="ml-auto" />
               </button>
+              <CanvasBlockIcon name="governance" />
             </h4>
             <div class="canvas-bmc-content text-sm text-gray-800 space-y-1.5">
               <template v-if="summary.governance.stages.length">
@@ -70,17 +130,54 @@
         <!-- Middle column: 2/3 + 1/3 -->
         <div class="canvas-bmc-col flex flex-col border-r-2 border-black">
           <div class="canvas-bmc-block flex-[2] border-b-2 border-black px-4 pt-2 pb-4">
-            <h4 class="canvas-bmc-block-title flex items-center gap-2 text-gray-900">
+            <h4 class="canvas-bmc-block-title flex flex-wrap items-center gap-2 text-gray-900">
               <button type="button" class="canvas-bmc-block-title-link" @click="requestSection('user-expectations')">
                 User Expectations
-                <CanvasBlockIcon name="expectations" class="ml-auto" />
               </button>
+              <button
+                type="button"
+                class="canvas-fw-chip"
+                :class="{ 'canvas-fw-chip--done': fwProgress.tasks }"
+                @click="toggleFwEdit('tasks')"
+              >
+                <template v-if="fwProgress.tasks">essentials ✓</template>
+                <template v-else>essentials — first task</template>
+              </button>
+              <CanvasBlockIcon name="expectations" />
             </h4>
             <div class="canvas-bmc-content text-sm text-gray-800 space-y-1.5">
+              <div v-if="showTasksStrip" class="canvas-fw-strip" @focusout="onStripFocusOut('tasks', $event)">
+                <label class="canvas-fw-label" for="fw-task-title">First task — what should be automated?</label>
+                <input
+                  id="fw-task-title"
+                  class="canvas-fw-input font-medium"
+                  type="text"
+                  placeholder="e.g. De-identify incoming letters"
+                  :value="firstTask?.title || ''"
+                  @input="patchFirstTask({ title: ($event.target as HTMLInputElement).value })"
+                />
+                <textarea
+                  id="fw-task-story"
+                  class="canvas-fw-input"
+                  rows="2"
+                  placeholder="As a …, I want …, so that …"
+                  :value="firstTask?.userStory || ''"
+                  @input="patchFirstTask({ userStory: ($event.target as HTMLTextAreaElement).value })"
+                ></textarea>
+                <label class="canvas-fw-label" for="fw-task-audience">Target population — who benefits?</label>
+                <input
+                  id="fw-task-audience"
+                  class="canvas-fw-input"
+                  type="text"
+                  placeholder="e.g. clinicians triaging referrals"
+                  :value="firstTask?.targetPopulation || ''"
+                  @input="patchFirstTask({ targetPopulation: ($event.target as HTMLInputElement).value })"
+                />
+              </div>
               <p><strong>{{ summary.userExpectations.taskCount }}</strong> tasks</p>
-              <div v-if="summary.userExpectations.tasks.length" class="space-y-2">
+              <div v-if="visibleTasks.length" class="space-y-2">
                 <div
-                  v-for="(t, i) in summary.userExpectations.tasks"
+                  v-for="(t, i) in visibleTasks"
                   :key="i"
                   class="border-l-2 border-gray-300 pl-2 py-0.5"
                 >
@@ -114,17 +211,47 @@
                   </button>
                 </div>
               </template>
-              <p v-if="isEmptyUserExpectations(summary.userExpectations)" class="italic text-gray-400">Not specified</p>
+              <p v-if="isEmptyUserExpectations(summary.userExpectations) && !showTasksStrip" class="italic text-gray-400">Not specified</p>
             </div>
           </div>
           <div class="canvas-bmc-block flex-[1] px-4 pt-2 pb-4">
-            <h4 class="canvas-bmc-block-title flex items-center gap-2 text-gray-900">
+            <h4 class="canvas-bmc-block-title flex flex-wrap items-center gap-2 text-gray-900">
               <button type="button" class="canvas-bmc-block-title-link" @click="requestSection('data-access')">
                 Data Access
-                <CanvasBlockIcon name="data" class="ml-auto" />
               </button>
+              <button
+                type="button"
+                class="canvas-fw-chip"
+                :class="{ 'canvas-fw-chip--done': fwProgress.dataAccess }"
+                @click="toggleFwEdit('dataAccess')"
+              >
+                <template v-if="fwProgress.dataAccess">essentials ✓</template>
+                <template v-else>essentials — main dataset</template>
+              </button>
+              <CanvasBlockIcon name="data" />
             </h4>
             <div class="canvas-bmc-content text-sm text-gray-800 space-y-1.5">
+              <div v-if="showDataAccessStrip" class="canvas-fw-strip" @focusout="onStripFocusOut('dataAccess', $event)">
+                <label class="canvas-fw-label" for="fw-dataset-title">Main dataset — what data does it touch?</label>
+                <input
+                  id="fw-dataset-title"
+                  class="canvas-fw-input"
+                  type="text"
+                  placeholder="e.g. Incoming patient letters"
+                  :value="firstDataset?.title || ''"
+                  @input="patchFirstDataset({ title: ($event.target as HTMLInputElement).value })"
+                />
+                <select
+                  id="fw-dataset-personal"
+                  class="canvas-fw-input"
+                  :value="personalDataAnswer"
+                  @change="setPersonalDataAnswer(($event.target as HTMLSelectElement).value)"
+                >
+                  <option value="">Contains personal data?</option>
+                  <option value="yes">Yes — contains personal data</option>
+                  <option value="no">No personal data</option>
+                </select>
+              </div>
               <template v-if="!isEmptyDataAccess(summary.dataAccess)">
                 <p><strong>{{ summary.dataAccess.datasetCount }}</strong> datasets</p>
                 <div v-if="Object.keys(summary.dataAccess.accessRightsSummary).length" class="text-xs">
@@ -134,7 +261,7 @@
                   <span v-for="s in summary.dataAccess.sensitivitySummary" :key="s" class="text-gray-600">{{ s }}</span>
                 </div>
               </template>
-              <p v-else class="italic text-gray-400">Not specified</p>
+              <p v-else-if="!showDataAccessStrip" class="italic text-gray-400">Not specified</p>
             </div>
           </div>
         </div>
@@ -142,13 +269,37 @@
         <!-- Right column: 1/2 + 1/2 -->
         <div class="canvas-bmc-col flex flex-col">
           <div class="canvas-bmc-block flex-1 border-b-2 border-black px-4 pt-2 pb-4">
-            <h4 class="canvas-bmc-block-title flex items-center gap-2 text-gray-900">
+            <h4 class="canvas-bmc-block-title flex flex-wrap items-center gap-2 text-gray-900">
               <button type="button" class="canvas-bmc-block-title-link" @click="requestSection('developer-feasibility')">
                 Developer Feasibility
-                <CanvasBlockIcon name="feasibility" class="ml-auto" />
               </button>
+              <button
+                type="button"
+                class="canvas-fw-chip"
+                :class="{ 'canvas-fw-chip--done': fwProgress.feasibility }"
+                @click="toggleFwEdit('feasibility')"
+              >
+                <template v-if="fwProgress.feasibility">essentials ✓</template>
+                <template v-else>essentials — risk gut-check</template>
+              </button>
+              <CanvasBlockIcon name="feasibility" />
             </h4>
             <div class="canvas-bmc-content text-sm text-gray-800 space-y-1.5">
+              <div v-if="showFeasibilityStrip" class="canvas-fw-strip" @focusout="onStripFocusOut('feasibility', $event)">
+                <label class="canvas-fw-label" for="fw-feasibility-risk">Overall technical risk — how risky does this feel?</label>
+                <select
+                  id="fw-feasibility-risk"
+                  class="canvas-fw-input"
+                  :value="canvasData.developerFeasibility?.technicalRisk || ''"
+                  @change="setTechnicalRisk(($event.target as HTMLSelectElement).value)"
+                >
+                  <option value="">Select risk level…</option>
+                  <option value="low">Low — mature tech, clear path</option>
+                  <option value="medium">Medium — some unknowns</option>
+                  <option value="high">High — significant unknowns</option>
+                  <option value="critical">Critical — unproven approach</option>
+                </select>
+              </div>
               <div v-if="summary.developerFeasibility.trlCurrent !== null || summary.developerFeasibility.trlTarget !== null">
                 <span>TRL</span>
                 <span v-if="summary.developerFeasibility.trlCurrent !== null">
@@ -157,7 +308,7 @@
                 </span>
                 <span v-else-if="summary.developerFeasibility.trlTarget !== null">target {{ summary.developerFeasibility.trlTarget }}</span>
               </div>
-              <p v-if="summary.developerFeasibility.technicalRisk">Risk: <span class="capitalize">{{ summary.developerFeasibility.technicalRisk }}</span></p>
+              <p v-if="summary.developerFeasibility.technicalRisk && !showFeasibilityStrip">Risk: <span class="capitalize">{{ summary.developerFeasibility.technicalRisk }}</span></p>
               <p v-if="summary.developerFeasibility.effortEstimate">Effort: {{ summary.developerFeasibility.effortEstimate }}</p>
               <p v-if="summary.developerFeasibility.amortizationMonths !== null" class="text-xs">
                 ~{{ summary.developerFeasibility.amortizationMonths!.toFixed(1) }} mo until amortization
@@ -177,24 +328,52 @@
                   />
                 </div>
               </div>
-              <p v-if="isEmptyDeveloperFeasibility(summary.developerFeasibility) && summary.userExpectations.taskCount === 0" class="italic text-gray-400">Not specified</p>
+              <p v-if="isEmptyDeveloperFeasibility(summary.developerFeasibility) && summary.userExpectations.taskCount === 0 && !showFeasibilityStrip" class="italic text-gray-400">Not specified</p>
             </div>
           </div>
           <div class="canvas-bmc-block flex-1 px-4 pt-2 pb-4">
-            <h4 class="canvas-bmc-block-title flex items-center gap-2 text-gray-900">
+            <h4 class="canvas-bmc-block-title flex flex-wrap items-center gap-2 text-gray-900">
               <button type="button" class="canvas-bmc-block-title-link" @click="requestSection('outcomes')">
                 Outcomes
-                <CanvasBlockIcon name="outcomes" class="ml-auto" />
               </button>
+              <button
+                type="button"
+                class="canvas-fw-chip"
+                :class="{ 'canvas-fw-chip--done': fwProgress.outcomes }"
+                @click="toggleFwEdit('outcomes')"
+              >
+                <template v-if="fwProgress.outcomes">essentials ✓</template>
+                <template v-else>essentials — main deliverable</template>
+              </button>
+              <CanvasBlockIcon name="outcomes" />
             </h4>
             <div class="canvas-bmc-content text-sm text-gray-800 space-y-2">
+              <div v-if="showOutcomesStrip" class="canvas-fw-strip" @focusout="onStripFocusOut('outcomes', $event)">
+                <label class="canvas-fw-label" for="fw-deliverable-title">Main deliverable — what will exist at the end?</label>
+                <input
+                  id="fw-deliverable-title"
+                  class="canvas-fw-input"
+                  type="text"
+                  placeholder="e.g. Triage dashboard"
+                  :value="firstDeliverable?.title || ''"
+                  @input="patchFirstDeliverable({ title: ($event.target as HTMLInputElement).value })"
+                />
+                <input
+                  id="fw-deliverable-type"
+                  class="canvas-fw-input"
+                  type="text"
+                  placeholder="Type — e.g. Software, Report, Dataset"
+                  :value="firstDeliverable?.type || ''"
+                  @input="patchFirstDeliverable({ type: ($event.target as HTMLInputElement).value })"
+                />
+              </div>
               <template v-if="!isEmptyOutcomes(summary.outcomes)">
-                <template v-if="summary.outcomes.deliverables.length">
+                <template v-if="visibleDeliverables.length">
                   <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">
                     {{ summary.outcomes.deliverableCount }} {{ summary.outcomes.deliverableCount === 1 ? 'deliverable' : 'deliverables' }}
                   </p>
                   <ul class="list-none space-y-0.5 text-xs">
-                    <li v-for="(d, i) in summary.outcomes.deliverables" :key="'d-' + i">
+                    <li v-for="(d, i) in visibleDeliverables" :key="'d-' + i">
                       <a
                         v-if="isLink(d.pid)"
                         :href="d.pid!"
@@ -235,7 +414,7 @@
                   </ul>
                 </template>
               </template>
-              <p v-else class="italic text-gray-400">Not specified</p>
+              <p v-else-if="!showOutcomesStrip" class="italic text-gray-400">Not specified</p>
             </div>
           </div>
         </div>
@@ -255,18 +434,140 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useCanvasData } from '@/composables/useCanvasData'
 import { computeCanvasSummary, type CanvasSummaryData, isLink, parseUserStory } from '@/utils/canvasSummary'
+import { computeFrameworkProgress } from '@/utils/frameworkProgress'
 import { formatDeploymentCost } from '@/utils/deploymentCost'
+import type { Dataset, Deliverable, Requirement } from '@/types/canvas'
 import InfoTooltip from '../InfoTooltip.vue'
 import CanvasBlockIcon from './CanvasBlockIcon.vue'
 
-const { canvasData, requestSection } = useCanvasData()
+const {
+  canvasData,
+  requestSection,
+  updateProject,
+  updateUserExpectations,
+  updateDeveloperFeasibility,
+  updateDataAccess,
+  updateOutcomes,
+} = useCanvasData()
 
 const summary = computed<CanvasSummaryData>(() => computeCanvasSummary(canvasData.value))
 const today = new Date().toISOString().split('T')[0]
 const version = computed(() => canvasData.value.project?.version || canvasData.value.version || '0.1.0')
+
+// ── Essentials strips: the six loose entry boxes, one subset field group per block ──
+
+const fwProgress = computed(() => computeFrameworkProgress(canvasData.value))
+
+type FwBlock = 'project' | 'tasks' | 'feasibility' | 'dataAccess' | 'outcomes'
+const blockComplete = computed<Record<FwBlock, boolean>>(() => ({
+  project: fwProgress.value.summary && fwProgress.value.benefit,
+  tasks: fwProgress.value.tasks,
+  feasibility: fwProgress.value.feasibility,
+  dataAccess: fwProgress.value.dataAccess,
+  outcomes: fwProgress.value.outcomes,
+}))
+
+// Strips start open where the box is incomplete. Completing a box must NOT
+// collapse its strip by itself — the first keystroke of the last field would
+// close the editor mid-typing. A complete strip collapses when focus leaves
+// its block, or from its chip (guide, don't force).
+const fwEdit = ref<Record<FwBlock, boolean>>({
+  project: !blockComplete.value.project,
+  tasks: !blockComplete.value.tasks,
+  feasibility: !blockComplete.value.feasibility,
+  dataAccess: !blockComplete.value.dataAccess,
+  outcomes: !blockComplete.value.outcomes,
+})
+
+function toggleFwEdit(block: FwBlock) {
+  fwEdit.value[block] = !fwEdit.value[block]
+}
+
+// A box edited back to incomplete (e.g. its title cleared) reopens its strip
+watch(blockComplete, (now, prev) => {
+  for (const block of Object.keys(now) as FwBlock[]) {
+    if (prev[block] && !now[block]) fwEdit.value[block] = true
+  }
+})
+
+function onStripFocusOut(block: FwBlock, event: FocusEvent) {
+  const strip = event.currentTarget as HTMLElement
+  const next = event.relatedTarget as HTMLElement | null
+  // focus moved within this block (another strip field, the chip, the title) → keep editing
+  if (next && strip.closest('.canvas-bmc-block')?.contains(next)) return
+  if (blockComplete.value[block]) fwEdit.value[block] = false
+}
+
+const showProjectStrip = computed(() => fwEdit.value.project)
+const showTasksStrip = computed(() => fwEdit.value.tasks)
+const showFeasibilityStrip = computed(() => fwEdit.value.feasibility)
+const showDataAccessStrip = computed(() => fwEdit.value.dataAccess)
+const showOutcomesStrip = computed(() => fwEdit.value.outcomes)
+
+const firstTask = computed<Requirement | undefined>(() => canvasData.value.userExpectations?.requirements?.[0])
+const firstDataset = computed<Dataset | undefined>(() => canvasData.value.dataAccess?.datasets?.[0])
+const firstDeliverable = computed<Deliverable | undefined>(() => canvasData.value.outcomes?.deliverables?.[0])
+
+// Hide the first item from the rendered lists while its strip edits it (avoids double display)
+const visibleTasks = computed(() =>
+  showTasksStrip.value ? summary.value.userExpectations.tasks.slice(1) : summary.value.userExpectations.tasks
+)
+const visibleDeliverables = computed(() =>
+  showOutcomesStrip.value ? summary.value.outcomes.deliverables.slice(1) : summary.value.outcomes.deliverables
+)
+
+function patchFirstTask(patch: Partial<Requirement>) {
+  const requirements = canvasData.value.userExpectations?.requirements || []
+  if (requirements.length === 0) {
+    updateUserExpectations({ requirements: [{ id: `req-${Date.now()}`, title: '', benefits: [], ...patch }] })
+  } else {
+    const updated = [...requirements]
+    updated[0] = { ...updated[0], ...patch }
+    updateUserExpectations({ requirements: updated })
+  }
+}
+
+function setTechnicalRisk(value: string) {
+  updateDeveloperFeasibility({
+    technicalRisk: (value || undefined) as 'low' | 'medium' | 'high' | 'critical' | undefined,
+  })
+}
+
+function patchFirstDataset(patch: Partial<Dataset>) {
+  const datasets = canvasData.value.dataAccess?.datasets || []
+  if (datasets.length === 0) {
+    updateDataAccess({ datasets: [{ id: `dataset-${Date.now()}`, title: '', ...patch }] })
+  } else {
+    const updated = [...datasets]
+    updated[0] = { ...updated[0], ...patch }
+    updateDataAccess({ datasets: updated })
+  }
+}
+
+const personalDataAnswer = computed(() => {
+  const value = firstDataset.value?.containsPersonalData
+  if (value === true) return 'yes'
+  if (value === false) return 'no'
+  return ''
+})
+
+function setPersonalDataAnswer(answer: string) {
+  patchFirstDataset({ containsPersonalData: answer === '' ? undefined : answer === 'yes' })
+}
+
+function patchFirstDeliverable(patch: Partial<Deliverable>) {
+  const deliverables = canvasData.value.outcomes?.deliverables || []
+  if (deliverables.length === 0) {
+    updateOutcomes({ deliverables: [{ id: `deliverable-${Date.now()}`, title: '', type: '', ...patch }] })
+  } else {
+    const updated = [...deliverables]
+    updated[0] = { ...updated[0], ...patch }
+    updateOutcomes({ deliverables: updated })
+  }
+}
 
 const feasibilityProgress = computed(() => {
   const n = summary.value.developerFeasibility.tasksWithDedicatedFeasibility.length
@@ -279,11 +580,6 @@ function formatDeploymentCostSummary(totals: Record<string, number>): string {
   const entries = Object.entries(totals).filter(([, amount]) => amount > 0)
   if (entries.length === 0) return ''
   return entries.map(([currency, amount]) => formatDeploymentCost(amount, currency)).join(' + ')
-}
-
-function isEmptyProject(p: CanvasSummaryData['project']): boolean {
-  const noTitle = !p.title || p.title === 'Untitled Project'
-  return noTitle && !p.description && !p.stage && !p.headlineValue && !p.primaryValueDriver && p.domain.length === 0
 }
 
 function isEmptyUserExpectations(u: CanvasSummaryData['userExpectations']): boolean {
@@ -362,7 +658,6 @@ function isEmptyOutcomes(o: CanvasSummaryData['outcomes']): boolean {
   gap: 0.5rem;
   flex: 1;
   min-width: 0;
-  width: 100%;
   text-align: left;
   background: none;
   border: none;
@@ -417,6 +712,72 @@ function isEmptyOutcomes(o: CanvasSummaryData['outcomes']): boolean {
 .canvas-feasibility-fill {
   background: linear-gradient(180deg, #374151 0%, #1f2937 100%);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+/* Essentials strips: seamless inputs for the loose entry level */
+.canvas-fw-chip {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 0.1rem 0.5rem;
+  border: 1px solid rgb(209 213 219);
+  border-radius: 9999px;
+  color: rgb(107 114 128);
+  background: rgb(249 250 251);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  /* chips live inside the uppercase block-title h4 */
+  text-transform: none;
+}
+.canvas-fw-chip:hover {
+  border-color: rgb(14 165 233);
+  color: rgb(2 132 199);
+}
+.canvas-fw-chip--done {
+  color: rgb(21 128 61);
+  border-color: rgb(187 247 208);
+  background: rgb(240 253 244);
+}
+.canvas-fw-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-bottom: 0.625rem;
+}
+.canvas-fw-label {
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgb(107 114 128);
+  font-weight: 600;
+}
+.canvas-fw-input {
+  width: 100%;
+  font-size: 0.8125rem;
+  padding: 0.3rem 0.45rem;
+  border: 1px dashed rgb(203 213 225);
+  border-radius: 0.25rem;
+  background: rgb(249 250 251);
+  color: rgb(17 24 39);
+}
+.canvas-fw-input::placeholder {
+  color: rgb(156 163 175);
+  font-style: italic;
+}
+.canvas-fw-input:focus {
+  outline: none;
+  border-style: solid;
+  border-color: rgb(14 165 233);
+  background: white;
+  box-shadow: 0 0 0 1px rgb(14 165 233 / 0.3);
+}
+
+@media print {
+  .canvas-fw-chip,
+  .canvas-fw-strip {
+    display: none;
+  }
 }
 
 .user-story-formulaic {

--- a/src/components/sections/DataAccessSensitivity.vue
+++ b/src/components/sections/DataAccessSensitivity.vue
@@ -26,18 +26,158 @@
         />
       </template>
     </MultiValueInput>
+
+    <!-- Task-level data access: tasks come from Tasks & Benefits (single ground truth) -->
+    <div class="border-t border-gray-200 pt-6 space-y-4">
+      <div>
+        <h3 class="text-lg font-semibold text-gray-900 flex items-center gap-2">
+          <span>Task-Level Data Access</span>
+          <InfoTooltip
+            content="<strong>What goes here:</strong> For each task, select which datasets it uses and what the agent may do with them (read / modify / process / generate).<br/><br/><strong>Single ground truth:</strong> Tasks are defined once in Tasks &amp; Benefits and appear here automatically — exactly like task-level feasibility.<br/><br/><strong>Compliance flags:</strong> Linking a restricted or personal-data dataset to a task whose agent uses a frontier model raises an advisory flag (data-processing agreement, GDPR review, or enterprise licence may be needed). Flags never block the form."
+            position="top"
+          />
+        </h3>
+        <p class="section-description">
+          Which task uses which dataset, and what may the agent do with it? Tasks defined in
+          Tasks &amp; Benefits appear here automatically. Sensitive datasets combined with a
+          frontier model raise an advisory compliance flag.
+        </p>
+      </div>
+
+      <div v-if="requirements.length === 0" class="text-sm text-gray-500 italic">
+        No tasks defined yet.
+        <button
+          type="button"
+          class="text-primary-600 hover:text-primary-800 underline font-medium not-italic"
+          @click="requestSection('user-expectations')"
+        >
+          Define tasks in Tasks &amp; Benefits
+        </button>
+        — they will appear here automatically.
+      </div>
+      <div v-else-if="localDatasets.length === 0" class="text-sm text-gray-500 italic">
+        Add a dataset above first, then link it to your tasks here.
+      </div>
+
+      <div v-else class="space-y-4">
+        <div
+          v-for="requirement in requirements"
+          :key="requirement.id"
+          class="border border-gray-200 rounded-lg p-4"
+        >
+          <div class="flex items-start justify-between gap-3 mb-3 flex-wrap">
+            <h4 class="font-medium text-gray-900">{{ requirement.title || requirement.id }}</h4>
+            <span
+              class="text-xs px-2 py-0.5 rounded-full border whitespace-nowrap"
+              :class="modelChipClass(requirement)"
+            >
+              {{ modelChipLabel(requirement) }}
+            </span>
+          </div>
+
+          <p class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-1.5">Datasets used by this task</p>
+          <div class="flex flex-wrap gap-2 mb-3">
+            <button
+              v-for="dataset in localDatasets"
+              :key="dataset.id"
+              type="button"
+              class="text-sm px-3 py-1 rounded-full border transition-colors"
+              :class="isLinked(requirement, dataset.id)
+                ? 'bg-primary-50 border-primary-500 text-primary-700 font-medium'
+                : 'border-gray-300 text-gray-600 hover:border-gray-400'"
+              :aria-pressed="isLinked(requirement, dataset.id)"
+              @click="toggleDatasetLink(requirement, dataset.id)"
+            >
+              {{ dataset.title || 'Untitled dataset' }}
+              <span
+                v-if="isSensitiveDataset(dataset)"
+                class="ml-1 text-amber-600"
+                title="Restricted access or personal data"
+              >•</span>
+            </button>
+          </div>
+
+          <div v-if="linkedDatasets(requirement).length > 0" class="space-y-3">
+            <div
+              v-for="{ link, dataset } in linkedDatasets(requirement)"
+              :key="link.datasetId"
+              class="rounded-md bg-gray-50 border border-gray-200 p-3"
+            >
+              <div class="flex items-center justify-between gap-2 flex-wrap mb-2">
+                <span class="text-sm font-medium text-gray-800">{{ dataset.title || 'Untitled dataset' }}</span>
+                <span class="flex gap-1.5 text-xs">
+                  <span v-if="dataset.accessRights" class="px-1.5 py-0.5 rounded bg-gray-200 text-gray-700 capitalize">
+                    {{ dataset.accessRights }}
+                  </span>
+                  <span v-if="dataset.containsPersonalData" class="px-1.5 py-0.5 rounded bg-amber-100 text-amber-800">
+                    personal data
+                  </span>
+                </span>
+              </div>
+
+              <div class="flex items-center gap-4 flex-wrap">
+                <span class="text-xs text-gray-500">Agent may:</span>
+                <label
+                  v-for="action in AGENT_ACTIONS"
+                  :key="action"
+                  class="inline-flex items-center gap-1.5 text-sm text-gray-700 capitalize"
+                >
+                  <input
+                    type="checkbox"
+                    class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                    :checked="hasAction(link, action)"
+                    @change="toggleAction(requirement, link.datasetId, action)"
+                  />
+                  {{ action }}
+                </label>
+              </div>
+
+              <input
+                type="text"
+                class="mt-2 w-full text-sm border border-gray-200 rounded px-2 py-1 bg-white placeholder-gray-400 focus:border-primary-500 focus:ring-primary-500"
+                placeholder="Notes (e.g. DPA in place, de-identified before this step)"
+                :value="link.notes || ''"
+                @change="updateLinkNotes(requirement, link.datasetId, ($event.target as HTMLInputElement).value)"
+              />
+
+              <div
+                v-if="linkFlag(requirement, link)"
+                class="mt-2 text-sm rounded-md px-3 py-2 flex gap-2"
+                :class="linkFlag(requirement, link)!.level === 'warning'
+                  ? 'bg-amber-50 border border-amber-300 text-amber-800'
+                  : 'bg-blue-50 border border-blue-200 text-blue-800'"
+              >
+                <span aria-hidden="true">{{ linkFlag(requirement, link)!.level === 'warning' ? '⚠' : 'ℹ' }}</span>
+                <span>{{ linkFlag(requirement, link)!.message }}</span>
+              </div>
+            </div>
+
+            <p v-if="taskHasCleanLinks(requirement)" class="text-xs text-green-700 flex items-center gap-1">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+              </svg>
+              No compliance flags for this task
+            </p>
+          </div>
+          <p v-else class="text-sm text-gray-500 italic">
+            No datasets linked. Select the datasets this task's agent works with.
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import MultiValueInput from '../MultiValueInput.vue'
 import DatasetItem from '../DatasetItem.vue'
 import InfoTooltip from '../InfoTooltip.vue'
-import type { Dataset } from '@/types/canvas'
+import type { AgentDataAction, Dataset, Requirement, TaskDatasetLink } from '@/types/canvas'
 import { useCanvasData } from '@/composables/useCanvasData'
+import { evaluateTaskDatasetLink, type DataAccessFlag } from '@/utils/dataAccessWarnings'
 
-const { canvasData, updateDataAccess } = useCanvasData()
+const { canvasData, updateDataAccess, updateUserExpectations, requestSection } = useCanvasData()
 
 // Initialize with proper deep copying of nested arrays
 const initLocalDatasets = (): Dataset[] => {
@@ -83,10 +223,114 @@ watch(
 watch(localDatasets, async () => {
   // Skip if we're currently syncing from canvasData to avoid circular updates
   if (isSyncingFromCanvas) return
-  
+
   isLocalUpdate = true
   updateDataAccess({ datasets: [...localDatasets.value] })
   await nextTick()
   isLocalUpdate = false
 }, { deep: true, immediate: false })
+
+// ── Task-level data access (mirrors the task-level feasibility mechanism) ──
+
+const AGENT_ACTIONS: AgentDataAction[] = ['read', 'modify', 'process', 'generate']
+
+const requirements = computed(() => canvasData.value.userExpectations?.requirements || [])
+
+function updateRequirement(taskId: string, updatedRequirement: Requirement) {
+  const reqs = canvasData.value.userExpectations?.requirements || []
+  const index = reqs.findIndex((r) => r.id === taskId)
+  if (index === -1) return
+
+  const updatedRequirements = [...reqs]
+  updatedRequirements[index] = updatedRequirement
+  updateUserExpectations({ requirements: updatedRequirements })
+}
+
+function isLinked(requirement: Requirement, datasetId: string): boolean {
+  return (requirement.dataAccess?.datasetLinks || []).some((l) => l.datasetId === datasetId)
+}
+
+function toggleDatasetLink(requirement: Requirement, datasetId: string) {
+  const links = requirement.dataAccess?.datasetLinks || []
+  const newLinks = isLinked(requirement, datasetId)
+    ? links.filter((l) => l.datasetId !== datasetId)
+    : [...links, { datasetId, agentActions: [] as AgentDataAction[] }]
+
+  updateRequirement(requirement.id, {
+    ...requirement,
+    dataAccess: newLinks.length > 0 ? { datasetLinks: newLinks } : undefined,
+  })
+}
+
+/** Linked datasets that still exist (dangling links are hidden but preserved in data) */
+function linkedDatasets(requirement: Requirement): Array<{ link: TaskDatasetLink; dataset: Dataset }> {
+  const byId = new Map(localDatasets.value.map((d) => [d.id, d]))
+  return (requirement.dataAccess?.datasetLinks || [])
+    .map((link) => ({ link, dataset: byId.get(link.datasetId) }))
+    .filter((entry): entry is { link: TaskDatasetLink; dataset: Dataset } => entry.dataset !== undefined)
+}
+
+function hasAction(link: TaskDatasetLink, action: AgentDataAction): boolean {
+  return (link.agentActions || []).includes(action)
+}
+
+function updateLink(requirement: Requirement, datasetId: string, patch: Partial<TaskDatasetLink>) {
+  const links = (requirement.dataAccess?.datasetLinks || []).map((l) =>
+    l.datasetId === datasetId ? { ...l, ...patch } : l
+  )
+  updateRequirement(requirement.id, { ...requirement, dataAccess: { datasetLinks: links } })
+}
+
+function toggleAction(requirement: Requirement, datasetId: string, action: AgentDataAction) {
+  const link = (requirement.dataAccess?.datasetLinks || []).find((l) => l.datasetId === datasetId)
+  if (!link) return
+  const actions = link.agentActions || []
+  const newActions = actions.includes(action)
+    ? actions.filter((a) => a !== action)
+    : [...actions, action]
+  updateLink(requirement, datasetId, { agentActions: newActions })
+}
+
+function updateLinkNotes(requirement: Requirement, datasetId: string, notes: string) {
+  updateLink(requirement, datasetId, { notes: notes.trim() || undefined })
+}
+
+function linkFlag(requirement: Requirement, link: TaskDatasetLink): DataAccessFlag | null {
+  const dataset = localDatasets.value.find((d) => d.id === link.datasetId)
+  if (!dataset) return null
+  return evaluateTaskDatasetLink(requirement, dataset, link)
+}
+
+function taskHasCleanLinks(requirement: Requirement): boolean {
+  const linked = linkedDatasets(requirement)
+  return linked.length > 0 && linked.every(({ link }) => linkFlag(requirement, link) === null)
+}
+
+function isSensitiveDataset(dataset: Dataset): boolean {
+  return Boolean(
+    dataset.containsPersonalData ||
+    (dataset.accessRights && ['restricted', 'confidential', 'highly-restricted'].includes(dataset.accessRights))
+  )
+}
+
+function modelChipLabel(requirement: Requirement): string {
+  const feasibility = requirement.feasibility
+  if (feasibility?.modelName?.trim()) return feasibility.modelName
+  switch (feasibility?.modelSelection) {
+    case 'frontier-model': return 'Frontier model'
+    case 'open-source': return 'Open-source model'
+    case 'fine-tuned': return 'Fine-tuned model'
+    case 'custom': return 'Custom model'
+    case 'other': return 'Other model'
+    case 'none': return 'No LLM (deterministic)'
+    default: return 'Model not set'
+  }
+}
+
+function modelChipClass(requirement: Requirement): string {
+  const selection = requirement.feasibility?.modelSelection
+  if (selection === 'frontier-model') return 'border-amber-400 bg-amber-50 text-amber-700'
+  if (selection === undefined) return 'border-gray-300 text-gray-500'
+  return 'border-gray-300 bg-gray-50 text-gray-600'
+}
 </script>

--- a/src/composables/useCanvasData.ts
+++ b/src/composables/useCanvasData.ts
@@ -6,6 +6,7 @@ import { ref, computed, watch } from 'vue'
 import type { CanvasData, Milestone } from '@/types/canvas'
 import type { BenefitDisplayState } from '@/types/benefitDisplay'
 import { getTimeSavedPerUnit, getOversightMinutes } from '@/utils/timeBenefits'
+import { collectDataAccessFlags } from '@/utils/dataAccessWarnings'
 import type { FocusFieldRequest } from '@/utils/fieldNavigation'
 
 const STORAGE_KEY = 'agentic-automation-canvas-data'
@@ -533,6 +534,21 @@ export function useCanvasData() {
     return errors
   }
 
+  // Advisory compliance flags from task-level data access (warnings only; hints stay inline in the tab)
+  const validateTaskDataAccess = (): ValidationError[] => {
+    const requirements = canvasData.value.userExpectations?.requirements || []
+    return collectDataAccessFlags(canvasData.value)
+      .filter((flag) => flag.level === 'warning')
+      .map((flag) => {
+        const index = requirements.findIndex((r) => r.id === flag.taskId)
+        return {
+          field: `requirements[${index}].dataAccess`,
+          message: flag.message,
+          severity: 'warning' as const,
+        }
+      })
+  }
+
   const validateOutcomes = (): ValidationError[] => {
     const errors: ValidationError[] = []
     const outcomes = canvasData.value.outcomes
@@ -583,6 +599,7 @@ export function useCanvasData() {
     allErrors.push(...validateProject())
     allErrors.push(...validateRequirements())
     allErrors.push(...validateDatasets())
+    allErrors.push(...validateTaskDataAccess())
     allErrors.push(...validateOutcomes())
 
     const errors = allErrors.filter(e => e.severity === 'error')

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -139,6 +139,23 @@ export interface RequirementFeasibility {
   deploymentCost?: DeploymentCost
 }
 
+/** What an agent may do with a dataset within a task */
+export type AgentDataAction = 'read' | 'modify' | 'process' | 'generate'
+
+/** Link between a task and one dataset it uses, with agent permissions */
+export interface TaskDatasetLink {
+  /** Dataset.id from dataAccess.datasets (single ground truth for datasets) */
+  datasetId: string
+  /** What the agent is allowed to do with this dataset */
+  agentActions?: AgentDataAction[]
+  notes?: string
+}
+
+/** Per-task data access: which datasets this task uses and what the agent may do with them */
+export interface RequirementDataAccess {
+  datasetLinks?: TaskDatasetLink[]
+}
+
 export interface Requirement {
   id: string
   title: string
@@ -163,6 +180,8 @@ export interface Requirement {
   targetPopulation?: string
   /** Optional per-task feasibility (overrides or complements global DeveloperFeasibility) */
   feasibility?: RequirementFeasibility
+  /** Optional per-task data access links (edited from the Data Access tab, like feasibility) */
+  dataAccess?: RequirementDataAccess
 }
 
 export interface Person {

--- a/src/utils/agent-instructions.spec.ts
+++ b/src/utils/agent-instructions.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { generateAgentInstructions } from './agent-instructions'
+import type { CanvasData } from '@/types/canvas'
+
+function canvasWithLinks(): CanvasData {
+  return {
+    project: { title: 'Clinical workflow', description: 'De-identify, then extract' },
+    userExpectations: {
+      requirements: [
+        {
+          id: 'task-deid',
+          title: 'De-identify letters',
+          benefits: [],
+          dataAccess: {
+            datasetLinks: [{ datasetId: 'ds-letters', agentActions: ['read', 'process', 'generate'] }],
+          },
+        },
+        {
+          id: 'task-extract',
+          title: 'Clinical extraction',
+          benefits: [],
+          dataAccess: {
+            datasetLinks: [{ datasetId: 'ds-clean', agentActions: ['read'], notes: 'only cleaned data' }],
+          },
+        },
+      ],
+    },
+    dataAccess: {
+      datasets: [
+        { id: 'ds-letters', title: 'Patient letters', format: 'PDF', accessRights: 'restricted', containsPersonalData: true },
+        { id: 'ds-clean', title: 'De-identified corpus', format: 'CSV', accessRights: 'open' },
+      ],
+    },
+  }
+}
+
+describe('generateAgentInstructions — task data access', () => {
+  it('marks datasets containing personal data in the Data section', () => {
+    const md = generateAgentInstructions(canvasWithLinks())
+    expect(md).toContain('- Patient letters (PDF, restricted, contains personal data)')
+  })
+
+  it('lists per-task agent permissions with actions and notes', () => {
+    const md = generateAgentInstructions(canvasWithLinks())
+    expect(md).toContain('### Agent data access by task')
+    expect(md).toContain('- De-identify letters: Patient letters — read, process, generate')
+    expect(md).toContain('- Clinical extraction: De-identified corpus — read (only cleaned data)')
+  })
+
+  it('adds a guardrail line when task permissions exist', () => {
+    const md = generateAgentInstructions(canvasWithLinks())
+    expect(md).toContain('Do not let agents access datasets beyond the permissions listed above.')
+  })
+
+  it('omits the per-task subsection when no task links exist', () => {
+    const data = canvasWithLinks()
+    for (const req of data.userExpectations!.requirements!) {
+      delete req.dataAccess
+    }
+    const md = generateAgentInstructions(data)
+    expect(md).not.toContain('### Agent data access by task')
+    expect(md).not.toContain('Do not let agents access datasets')
+  })
+})

--- a/src/utils/agent-instructions.ts
+++ b/src/utils/agent-instructions.ts
@@ -126,9 +126,29 @@ function renderDataSources(data: CanvasData): string | undefined {
 
   const parts: string[] = ['', '## Data']
   for (const ds of datasets) {
-    const details = [ds.format, ds.accessRights].filter(Boolean).join(', ')
+    const details = [ds.format, ds.accessRights, ds.containsPersonalData && 'contains personal data']
+      .filter(Boolean)
+      .join(', ')
     parts.push(`- ${ds.title}${details ? ` (${details})` : ''}`)
   }
+
+  // Per-task agent permissions from task-level data access links
+  const datasetById = new Map(datasets.map((ds) => [ds.id, ds]))
+  const permissionLines: string[] = []
+  for (const req of data.userExpectations?.requirements ?? []) {
+    for (const link of req.dataAccess?.datasetLinks ?? []) {
+      const ds = datasetById.get(link.datasetId)
+      if (!ds) continue
+      const actions = link.agentActions?.length ? link.agentActions.join(', ') : 'no actions specified'
+      const note = link.notes ? ` (${link.notes})` : ''
+      permissionLines.push(`- ${req.title}: ${ds.title} — ${actions}${note}`)
+    }
+  }
+  if (permissionLines.length) {
+    parts.push('', '### Agent data access by task', ...permissionLines, '')
+    parts.push('Do not let agents access datasets beyond the permissions listed above.')
+  }
+
   return lines(...parts)
 }
 

--- a/src/utils/dataAccessRoundtrip.spec.ts
+++ b/src/utils/dataAccessRoundtrip.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { generateROCrate } from '@/utils/rocrate'
+import { parseROCrateToCanvas } from '@/utils/import'
+import type { ROCrateJSONLD } from '@/types/rocrate'
+import type { CanvasData } from '@/types/canvas'
+
+/**
+ * Export → import roundtrips for task-level data access.
+ * Links reference datasets by canvas dataset id, so ids must survive the trip.
+ */
+
+function clinicalCanvas(): CanvasData {
+  return {
+    project: { title: 'Clinical workflow', description: 'De-identify, then extract' },
+    userExpectations: {
+      requirements: [
+        {
+          id: 'task-deid',
+          title: 'De-identify letters',
+          benefits: [],
+          feasibility: { modelSelection: 'open-source' },
+          dataAccess: {
+            datasetLinks: [{ datasetId: 'ds-letters', agentActions: ['read', 'process', 'generate'] }],
+          },
+        },
+        {
+          id: 'task-extract',
+          title: 'Clinical extraction',
+          benefits: [],
+          feasibility: { modelSelection: 'frontier-model', modelCardUri: 'https://example.org/model-card' },
+          dataAccess: {
+            datasetLinks: [{ datasetId: 'ds-clean', agentActions: ['read', 'process'], notes: 'only cleaned data' }],
+          },
+        },
+      ],
+    },
+    dataAccess: {
+      datasets: [
+        { id: 'ds-letters', title: 'Patient letters', accessRights: 'restricted', containsPersonalData: true },
+        { id: 'ds-clean', title: 'De-identified corpus', accessRights: 'open', containsPersonalData: false },
+      ],
+    },
+  }
+}
+
+describe('task data access roundtrip', () => {
+  it('preserves canvas dataset ids as crate @ids (like requirement ids)', () => {
+    const crate = generateROCrate(clinicalCanvas())
+    const ids = crate['@graph'].map((e: { '@id': string }) => e['@id'])
+    expect(ids).toContain('#ds-letters')
+    expect(ids).toContain('#ds-clean')
+  })
+
+  it('exports aac:dataAccess on the step and links the step to datasets via prov:used', () => {
+    const crate = generateROCrate(clinicalCanvas())
+    const step = crate['@graph'].find((e: { '@id': string }) => e['@id'] === '#task-deid') as Record<string, unknown>
+    expect(step).toBeDefined()
+    expect(step['aac:dataAccess']).toEqual({
+      datasetLinks: [{ datasetId: 'ds-letters', agentActions: ['read', 'process', 'generate'] }],
+    })
+    const used = step['prov:used']
+    const usedIds = (Array.isArray(used) ? used : [used]).map((u) => (u as { '@id': string })['@id'])
+    expect(usedIds).toContain('#ds-letters')
+  })
+
+  it('keeps the model reference in prov:used alongside dataset links', () => {
+    const crate = generateROCrate(clinicalCanvas())
+    const step = crate['@graph'].find((e: { '@id': string }) => e['@id'] === '#task-extract') as Record<string, unknown>
+    const used = step['prov:used']
+    const usedIds = (Array.isArray(used) ? used : [used]).map((u) => (u as { '@id': string })['@id'])
+    expect(usedIds).toContain('https://example.org/model-card')
+    expect(usedIds).toContain('#ds-clean')
+  })
+
+  it('roundtrips datasetLinks through export and import unchanged', () => {
+    const crate = generateROCrate(clinicalCanvas()) as unknown as ROCrateJSONLD
+    const imported = parseROCrateToCanvas(crate)
+
+    const reqs = imported.userExpectations?.requirements ?? []
+    const deid = reqs.find((r) => r.id === 'task-deid')
+    const extract = reqs.find((r) => r.id === 'task-extract')
+
+    expect(deid?.dataAccess?.datasetLinks).toEqual([
+      { datasetId: 'ds-letters', agentActions: ['read', 'process', 'generate'] },
+    ])
+    expect(extract?.dataAccess?.datasetLinks).toEqual([
+      { datasetId: 'ds-clean', agentActions: ['read', 'process'], notes: 'only cleaned data' },
+    ])
+
+    // the datasets the links point at still exist under the same ids
+    const datasetIds = (imported.dataAccess?.datasets ?? []).map((d) => d.id)
+    expect(datasetIds).toContain('ds-letters')
+    expect(datasetIds).toContain('ds-clean')
+  })
+})

--- a/src/utils/dataAccessRoundtrip.spec.ts
+++ b/src/utils/dataAccessRoundtrip.spec.ts
@@ -92,4 +92,35 @@ describe('task data access roundtrip', () => {
     expect(datasetIds).toContain('ds-letters')
     expect(datasetIds).toContain('ds-clean')
   })
+
+  it('roundtrips links whose dataset id is not a valid crate fragment (e.g. a URI)', () => {
+    const data = clinicalCanvas()
+    data.dataAccess!.datasets![0].id = 'https://doi.org/10.1234/abc'
+    data.userExpectations!.requirements![0].dataAccess!.datasetLinks![0].datasetId =
+      'https://doi.org/10.1234/abc'
+
+    const crate = generateROCrate(data) as unknown as ROCrateJSONLD
+    const imported = parseROCrateToCanvas(crate)
+
+    // whatever id the dataset comes back under, the link must still point at it
+    const deid = imported.userExpectations?.requirements?.find((r) => r.id === 'task-deid')
+    const linkId = deid?.dataAccess?.datasetLinks?.[0]?.datasetId
+    const datasetIds = (imported.dataAccess?.datasets ?? []).map((d) => d.id)
+    expect(linkId).toBeTruthy()
+    expect(datasetIds).toContain(linkId)
+  })
+
+  it('never emits duplicate @ids when fallback and preserved dataset ids collide', () => {
+    const data = clinicalCanvas()
+    data.dataAccess!.datasets = [
+      // index 0 fails the fragment regex, so its fallback would be #dataset-0…
+      { id: 'https://doi.org/10.1234/abc', title: 'External corpus' },
+      // …which must not collide with this preserved id or with the task-deid step
+      { id: 'dataset-0', title: 'Legacy corpus' },
+      { id: 'task-deid', title: 'Same id as a task' },
+    ]
+    const crate = generateROCrate(data)
+    const ids = crate['@graph'].map((e: { '@id': string }) => e['@id'])
+    expect(new Set(ids).size).toBe(ids.length)
+  })
 })

--- a/src/utils/dataAccessWarnings.spec.ts
+++ b/src/utils/dataAccessWarnings.spec.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateTaskDatasetLink, collectDataAccessFlags } from './dataAccessWarnings'
+import type { CanvasData, Dataset, Requirement, TaskDatasetLink } from '@/types/canvas'
+
+function makeRequirement(overrides: Partial<Requirement> = {}): Requirement {
+  return {
+    id: 'task-1',
+    title: 'Extract key information',
+    benefits: [],
+    ...overrides,
+  }
+}
+
+function makeDataset(overrides: Partial<Dataset> = {}): Dataset {
+  return {
+    id: 'ds-1',
+    title: 'Patient letters',
+    ...overrides,
+  }
+}
+
+function makeLink(overrides: Partial<TaskDatasetLink> = {}): TaskDatasetLink {
+  return {
+    datasetId: 'ds-1',
+    agentActions: ['read'],
+    ...overrides,
+  }
+}
+
+function frontierTask(overrides: Partial<Requirement> = {}): Requirement {
+  return makeRequirement({
+    feasibility: { modelSelection: 'frontier-model' },
+    ...overrides,
+  })
+}
+
+describe('evaluateTaskDatasetLink', () => {
+  it('returns null for an open, non-personal dataset even with a frontier model', () => {
+    const flag = evaluateTaskDatasetLink(
+      frontierTask(),
+      makeDataset({ accessRights: 'open', containsPersonalData: false }),
+      makeLink({ agentActions: ['read', 'process'] })
+    )
+    expect(flag).toBeNull()
+  })
+
+  it('warns when a frontier model reads a restricted dataset', () => {
+    const flag = evaluateTaskDatasetLink(
+      frontierTask(),
+      makeDataset({ accessRights: 'restricted' }),
+      makeLink({ agentActions: ['read'] })
+    )
+    expect(flag).not.toBeNull()
+    expect(flag!.level).toBe('warning')
+    expect(flag!.message).toContain('data-processing agreement')
+  })
+
+  it('warns when a frontier model processes a dataset containing personal data', () => {
+    const flag = evaluateTaskDatasetLink(
+      frontierTask(),
+      makeDataset({ accessRights: 'open', containsPersonalData: true }),
+      makeLink({ agentActions: ['process'] })
+    )
+    expect(flag).not.toBeNull()
+    expect(flag!.level).toBe('warning')
+  })
+
+  it('does not flag an on-premise/open-source model touching personal data (clinical step 1)', () => {
+    const flag = evaluateTaskDatasetLink(
+      makeRequirement({ feasibility: { modelSelection: 'open-source' } }),
+      makeDataset({ accessRights: 'restricted', containsPersonalData: true }),
+      makeLink({ agentActions: ['read', 'process', 'generate'] })
+    )
+    expect(flag).toBeNull()
+  })
+
+  it('does not flag a deterministic task (modelSelection none) on sensitive data', () => {
+    const flag = evaluateTaskDatasetLink(
+      makeRequirement({ feasibility: { modelSelection: 'none' } }),
+      makeDataset({ accessRights: 'confidential' }),
+      makeLink({ agentActions: ['process'] })
+    )
+    expect(flag).toBeNull()
+  })
+
+  it('does not warn when the agent only generates into a sensitive dataset', () => {
+    const flag = evaluateTaskDatasetLink(
+      frontierTask(),
+      makeDataset({ accessRights: 'highly-restricted' }),
+      makeLink({ agentActions: ['generate'] })
+    )
+    expect(flag).toBeNull()
+  })
+
+  it('hints to specify the model when a sensitive dataset is touched and no model is set', () => {
+    const flag = evaluateTaskDatasetLink(
+      makeRequirement(),
+      makeDataset({ accessRights: 'restricted' }),
+      makeLink({ agentActions: ['read'] })
+    )
+    expect(flag).not.toBeNull()
+    expect(flag!.level).toBe('hint')
+    expect(flag!.message.toLowerCase()).toContain('model')
+  })
+
+  it('hints to specify agent actions when a sensitive dataset is linked without actions', () => {
+    const flag = evaluateTaskDatasetLink(
+      frontierTask(),
+      makeDataset({ accessRights: 'restricted' }),
+      makeLink({ agentActions: [] })
+    )
+    expect(flag).not.toBeNull()
+    expect(flag!.level).toBe('hint')
+    expect(flag!.message.toLowerCase()).toContain('do with')
+  })
+})
+
+describe('collectDataAccessFlags', () => {
+  function clinicalCanvas(): CanvasData {
+    // Sebastian's acceptance scenario: on-premise de-identification, then frontier
+    // model on the cleaned corpus. Correctly configured → no flags at all.
+    return {
+      project: { title: 'Clinical workflow', description: '' },
+      userExpectations: {
+        requirements: [
+          makeRequirement({
+            id: 'task-deid',
+            title: 'De-identify letters',
+            feasibility: { modelSelection: 'open-source' },
+            dataAccess: {
+              datasetLinks: [
+                { datasetId: 'ds-letters', agentActions: ['read', 'process', 'generate'] },
+              ],
+            },
+          }),
+          makeRequirement({
+            id: 'task-extract',
+            title: 'Clinical extraction',
+            feasibility: { modelSelection: 'frontier-model' },
+            dataAccess: {
+              datasetLinks: [
+                { datasetId: 'ds-clean', agentActions: ['read', 'process'] },
+              ],
+            },
+          }),
+        ],
+      },
+      dataAccess: {
+        datasets: [
+          makeDataset({ id: 'ds-letters', title: 'Patient letters', accessRights: 'restricted', containsPersonalData: true }),
+          makeDataset({ id: 'ds-clean', title: 'De-identified corpus', accessRights: 'open', containsPersonalData: false }),
+        ],
+      },
+    }
+  }
+
+  it('produces no flags for the correctly configured clinical workflow', () => {
+    expect(collectDataAccessFlags(clinicalCanvas())).toEqual([])
+  })
+
+  it('flags exactly the misconfigured link when the frontier task reads raw letters', () => {
+    const data = clinicalCanvas()
+    data.userExpectations!.requirements![1].dataAccess!.datasetLinks!.push({
+      datasetId: 'ds-letters',
+      agentActions: ['read'],
+    })
+    const flags = collectDataAccessFlags(data)
+    expect(flags).toHaveLength(1)
+    expect(flags[0].taskId).toBe('task-extract')
+    expect(flags[0].datasetId).toBe('ds-letters')
+    expect(flags[0].level).toBe('warning')
+  })
+
+  it('ignores links to datasets that no longer exist', () => {
+    const data = clinicalCanvas()
+    data.userExpectations!.requirements![0].dataAccess!.datasetLinks!.push({
+      datasetId: 'ds-deleted',
+      agentActions: ['read'],
+    })
+    expect(collectDataAccessFlags(data)).toEqual([])
+  })
+})

--- a/src/utils/dataAccessWarnings.ts
+++ b/src/utils/dataAccessWarnings.ts
@@ -1,0 +1,98 @@
+/**
+ * Advisory compliance flags for task-level data access.
+ *
+ * A flag is raised when the combination of a task's model selection, a linked
+ * dataset's sensitivity, and the agent's permitted actions suggests the user
+ * may need a data-processing agreement, GDPR review, or enterprise licence.
+ * Flags are advisory only — they never block the form (guide, don't force).
+ */
+
+import type { AgentDataAction, CanvasData, Dataset, Requirement, TaskDatasetLink } from '@/types/canvas'
+
+export interface DataAccessFlag {
+  taskId: string
+  datasetId: string
+  level: 'warning' | 'hint'
+  message: string
+}
+
+const SENSITIVE_ACCESS_RIGHTS = new Set(['restricted', 'confidential', 'highly-restricted'])
+
+/** Actions through which an agent consumes dataset content (generate alone does not) */
+const CONSUMING_ACTIONS: AgentDataAction[] = ['read', 'modify', 'process']
+
+function isSensitive(dataset: Dataset): boolean {
+  if (dataset.containsPersonalData) return true
+  return dataset.accessRights !== undefined && SENSITIVE_ACCESS_RIGHTS.has(dataset.accessRights)
+}
+
+function sensitivityLabel(dataset: Dataset): string {
+  const parts: string[] = []
+  if (dataset.accessRights && SENSITIVE_ACCESS_RIGHTS.has(dataset.accessRights)) {
+    parts.push(dataset.accessRights)
+  }
+  if (dataset.containsPersonalData) {
+    parts.push('contains personal data')
+  }
+  return parts.join(', ')
+}
+
+export function evaluateTaskDatasetLink(
+  req: Requirement,
+  dataset: Dataset,
+  link: TaskDatasetLink
+): DataAccessFlag | null {
+  if (!isSensitive(dataset)) return null
+
+  const actions = link.agentActions ?? []
+  if (actions.length === 0) {
+    return {
+      taskId: req.id,
+      datasetId: dataset.id,
+      level: 'hint',
+      message: `Specify what the agent may do with "${dataset.title}" in task "${req.title}" (read / modify / process / generate).`,
+    }
+  }
+
+  const consumes = actions.some((a) => CONSUMING_ACTIONS.includes(a))
+  if (!consumes) return null
+
+  const model = req.feasibility?.modelSelection
+  if (model === undefined) {
+    return {
+      taskId: req.id,
+      datasetId: dataset.id,
+      level: 'hint',
+      message: `Task "${req.title}" lets an agent access the sensitive dataset "${dataset.title}" — select a model in Feasibility & Risks to check compliance.`,
+    }
+  }
+
+  if (model === 'frontier-model') {
+    return {
+      taskId: req.id,
+      datasetId: dataset.id,
+      level: 'warning',
+      message: `"${dataset.title}" (${sensitivityLabel(dataset)}) is accessed by an agent using a frontier model in task "${req.title}" — you may need a data-processing agreement (DPA), GDPR review, or an enterprise licence with the model provider.`,
+    }
+  }
+
+  return null
+}
+
+/** Evaluate every task↔dataset link in the canvas. Links to deleted datasets are ignored. */
+export function collectDataAccessFlags(data: CanvasData): DataAccessFlag[] {
+  const requirements = data.userExpectations?.requirements ?? []
+  const datasets = data.dataAccess?.datasets ?? []
+  const datasetById = new Map(datasets.map((d) => [d.id, d]))
+
+  const flags: DataAccessFlag[] = []
+  for (const req of requirements) {
+    for (const link of req.dataAccess?.datasetLinks ?? []) {
+      const dataset = datasetById.get(link.datasetId)
+      if (!dataset) continue
+      const flag = evaluateTaskDatasetLink(req, dataset, link)
+      if (flag) flags.push(flag)
+    }
+  }
+  return flags
+}

--- a/src/utils/fieldNavigation.spec.ts
+++ b/src/utils/fieldNavigation.spec.ts
@@ -52,6 +52,11 @@ describe('fieldToNavTarget', () => {
       sectionId: 'user-expectations', itemType: 'requirement', itemIndex: 2, domFieldId: 'req-volume-2',
     })
   })
+  it('maps requirements[2].dataAccess to the Data Access tab', () => {
+    expect(fieldToNavTarget('requirements[2].dataAccess')).toEqual({
+      sectionId: 'data-access', itemType: null, itemIndex: null, domFieldId: null,
+    })
+  })
   it('maps requirements[0].benefits to Edit Benefits button', () => {
     const result = fieldToNavTarget('requirements[0].benefits')
     expect(result?.sectionId).toBe('user-expectations')

--- a/src/utils/fieldNavigation.ts
+++ b/src/utils/fieldNavigation.ts
@@ -47,6 +47,10 @@ export function fieldToNavTarget(field: string): FocusFieldRequest | null {
   if (reqMatch) {
     const index = parseInt(reqMatch[1], 10)
     const subField = reqMatch[2] ?? ''
+    // Task-level data access is edited from the Data Access tab, not Tasks & Benefits
+    if (subField === 'dataAccess' || subField.startsWith('dataAccess.')) {
+      return { sectionId: 'data-access', itemType: null, itemIndex: null, domFieldId: null }
+    }
     const domMap: Record<string, string> = {
       'title':          `req-title-${index}`,
       'unitOfWork':     `req-unit-${index}`,

--- a/src/utils/frameworkProgress.spec.ts
+++ b/src/utils/frameworkProgress.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { computeFrameworkProgress } from './frameworkProgress'
+import type { CanvasData } from '@/types/canvas'
+
+function emptyCanvas(): CanvasData {
+  return { project: { title: '', description: '' } }
+}
+
+describe('computeFrameworkProgress', () => {
+  it('reports zero completed boxes for an empty canvas', () => {
+    const p = computeFrameworkProgress(emptyCanvas())
+    expect(p.summary).toBe(false)
+    expect(p.benefit).toBe(false)
+    expect(p.tasks).toBe(false)
+    expect(p.feasibility).toBe(false)
+    expect(p.dataAccess).toBe(false)
+    expect(p.outcomes).toBe(false)
+    expect(p.completeCount).toBe(0)
+  })
+
+  it('completes summary only when title and description are non-blank', () => {
+    const data = emptyCanvas()
+    data.project.title = 'Clinical letter triage'
+    expect(computeFrameworkProgress(data).summary).toBe(false)
+    data.project.description = '   '
+    expect(computeFrameworkProgress(data).summary).toBe(false)
+    data.project.description = 'Sort incoming letters automatically'
+    expect(computeFrameworkProgress(data).summary).toBe(true)
+  })
+
+  it('completes benefit with a headline value or a rough estimate', () => {
+    const withHeadline = emptyCanvas()
+    withHeadline.project.headlineValue = 'Save ~10 h/month'
+    expect(computeFrameworkProgress(withHeadline).benefit).toBe(true)
+
+    const withEstimate = emptyCanvas()
+    withEstimate.project.roughEstimateValue = 10
+    withEstimate.project.roughEstimateUnit = 'hours/month'
+    expect(computeFrameworkProgress(withEstimate).benefit).toBe(true)
+  })
+
+  it('completes tasks when the first task has a title and a user story', () => {
+    const data = emptyCanvas()
+    data.userExpectations = {
+      requirements: [{ id: 'r1', title: 'De-identify letters', benefits: [] }],
+    }
+    expect(computeFrameworkProgress(data).tasks).toBe(false)
+    data.userExpectations.requirements![0].userStory =
+      'As a clinician, I want letters triaged, so that I see urgent ones first'
+    expect(computeFrameworkProgress(data).tasks).toBe(true)
+  })
+
+  it('completes feasibility when a project-level technical risk is set', () => {
+    const data = emptyCanvas()
+    data.developerFeasibility = { technicalRisk: 'medium' }
+    expect(computeFrameworkProgress(data).feasibility).toBe(true)
+  })
+
+  it('completes dataAccess when a dataset has a title and an explicit personal-data answer', () => {
+    const data = emptyCanvas()
+    data.dataAccess = { datasets: [{ id: 'd1', title: 'Patient letters' }] }
+    expect(computeFrameworkProgress(data).dataAccess).toBe(false)
+    // an explicit "no" also counts as answered
+    data.dataAccess.datasets![0].containsPersonalData = false
+    expect(computeFrameworkProgress(data).dataAccess).toBe(true)
+  })
+
+  it('completes outcomes only when a deliverable has both title and type', () => {
+    const data = emptyCanvas()
+    // title alone is not enough: a typeless deliverable would raise a validation error
+    data.outcomes = { deliverables: [{ id: 'del1', title: 'Triage dashboard', type: '' }] }
+    expect(computeFrameworkProgress(data).outcomes).toBe(false)
+    data.outcomes.deliverables![0].type = 'software'
+    expect(computeFrameworkProgress(data).outcomes).toBe(true)
+  })
+
+  it('counts all six boxes on a fully filled framework', () => {
+    const data: CanvasData = {
+      project: {
+        title: 'Clinical letter triage',
+        description: 'Sort incoming letters automatically',
+        headlineValue: 'Save ~10 h/month',
+      },
+      userExpectations: {
+        requirements: [
+          {
+            id: 'r1',
+            title: 'De-identify letters',
+            userStory: 'As a clinician, I want letters triaged, so that I see urgent ones first',
+            benefits: [],
+          },
+        ],
+      },
+      developerFeasibility: { technicalRisk: 'medium' },
+      dataAccess: { datasets: [{ id: 'd1', title: 'Patient letters', containsPersonalData: true }] },
+      outcomes: { deliverables: [{ id: 'del1', title: 'Triage dashboard', type: 'software' }] },
+    }
+    const p = computeFrameworkProgress(data)
+    expect(p.completeCount).toBe(6)
+  })
+})

--- a/src/utils/frameworkProgress.spec.ts
+++ b/src/utils/frameworkProgress.spec.ts
@@ -39,6 +39,21 @@ describe('computeFrameworkProgress', () => {
     expect(computeFrameworkProgress(withEstimate).benefit).toBe(true)
   })
 
+  it('does not count a cleared rough estimate as a benefit', () => {
+    // v-model.number leaves '' when the input is emptied; older data can hold null
+    const cleared = emptyCanvas()
+    cleared.project.roughEstimateValue = '' as unknown as number
+    expect(computeFrameworkProgress(cleared).benefit).toBe(false)
+
+    const nulled = emptyCanvas()
+    nulled.project.roughEstimateValue = null as unknown as number
+    expect(computeFrameworkProgress(nulled).benefit).toBe(false)
+
+    const zero = emptyCanvas()
+    zero.project.roughEstimateValue = 0
+    expect(computeFrameworkProgress(zero).benefit).toBe(true)
+  })
+
   it('completes tasks when the first task has a title and a user story', () => {
     const data = emptyCanvas()
     data.userExpectations = {

--- a/src/utils/frameworkProgress.ts
+++ b/src/utils/frameworkProgress.ts
@@ -37,7 +37,8 @@ export function computeFrameworkProgress(data: CanvasData): FrameworkProgress {
   const deliverables = data.outcomes?.deliverables ?? []
 
   const summary = filled(project.title) && filled(project.description)
-  const benefit = filled(project.headlineValue) || project.roughEstimateValue !== undefined
+  // Number.isFinite also rejects the '' a cleared v-model.number input leaves behind, and null from older data
+  const benefit = filled(project.headlineValue) || Number.isFinite(project.roughEstimateValue)
   const tasks = requirements.some((r) => filled(r.title) && filled(r.userStory))
   const feasibility = data.developerFeasibility?.technicalRisk !== undefined
   const dataAccess = datasets.some((d) => filled(d.title) && d.containsPersonalData !== undefined)

--- a/src/utils/frameworkProgress.ts
+++ b/src/utils/frameworkProgress.ts
@@ -1,0 +1,50 @@
+/**
+ * Completion logic for the six "essentials" boxes on the Canvas Summary.
+ *
+ * The essentials are the loose entry level of the AAC — the framework level,
+ * in framework-vs-standard terms: a small subset of the full standard's
+ * fields (summary, benefit, task + user story, feasibility gut-check, data
+ * sensitivity, expected deliverable). Same fields, same export — this module
+ * only decides which boxes count as answered. The UI says "essentials"
+ * because "framework" already means agentic/compliance frameworks elsewhere
+ * in the canvas.
+ */
+
+import type { CanvasData } from '@/types/canvas'
+
+export interface FrameworkProgress {
+  /** Project title + one-line description */
+  summary: boolean
+  /** Headline value or rough estimate */
+  benefit: boolean
+  /** At least one task with a title and a user story */
+  tasks: boolean
+  /** Project-level technical risk gut-check */
+  feasibility: boolean
+  /** A named dataset with an explicit personal-data answer */
+  dataAccess: boolean
+  /** A named main deliverable */
+  outcomes: boolean
+  completeCount: number
+}
+
+const filled = (s: string | undefined): boolean => Boolean(s && s.trim())
+
+export function computeFrameworkProgress(data: CanvasData): FrameworkProgress {
+  const project = data.project
+  const requirements = data.userExpectations?.requirements ?? []
+  const datasets = data.dataAccess?.datasets ?? []
+  const deliverables = data.outcomes?.deliverables ?? []
+
+  const summary = filled(project.title) && filled(project.description)
+  const benefit = filled(project.headlineValue) || project.roughEstimateValue !== undefined
+  const tasks = requirements.some((r) => filled(r.title) && filled(r.userStory))
+  const feasibility = data.developerFeasibility?.technicalRisk !== undefined
+  const dataAccess = datasets.some((d) => filled(d.title) && d.containsPersonalData !== undefined)
+  // title AND type: a typeless deliverable would raise a validation error
+  const outcomes = deliverables.some((d) => filled(d.title) && filled(d.type))
+
+  const completeCount = [summary, benefit, tasks, feasibility, dataAccess, outcomes].filter(Boolean).length
+
+  return { summary, benefit, tasks, feasibility, dataAccess, outcomes, completeCount }
+}

--- a/src/utils/import.ts
+++ b/src/utils/import.ts
@@ -221,6 +221,30 @@ export function parseROCrateToCanvas(rocrate: ROCrateJSONLD): CanvasData {
             }
           }
         }
+        // Parse task-level data access (aac:dataAccess blob, mirrors feasibility)
+        if (step!['aac:dataAccess'] && typeof step!['aac:dataAccess'] === 'object') {
+          const rawLinks = (step!['aac:dataAccess'] as { datasetLinks?: unknown }).datasetLinks
+          if (Array.isArray(rawLinks)) {
+            const validActions = ['read', 'modify', 'process', 'generate']
+            const datasetLinks = rawLinks
+              .filter((l): l is Record<string, unknown> => Boolean(l) && typeof (l as Record<string, unknown>).datasetId === 'string')
+              .map((l) => {
+                const link: import('@/types/canvas').TaskDatasetLink = { datasetId: l.datasetId as string }
+                if (Array.isArray(l.agentActions)) {
+                  link.agentActions = l.agentActions.filter(
+                    (a): a is import('@/types/canvas').AgentDataAction => validActions.includes(a as string)
+                  )
+                }
+                if (typeof l.notes === 'string' && l.notes) {
+                  link.notes = l.notes
+                }
+                return link
+              })
+            if (datasetLinks.length > 0) {
+              req.dataAccess = { datasetLinks }
+            }
+          }
+        }
         return req
       })
 

--- a/src/utils/rocrate.spec.ts
+++ b/src/utils/rocrate.spec.ts
@@ -183,8 +183,9 @@ describe('generateROCrate', () => {
         },
       }
       const out = generateROCrate(dataWithSheet)
+      // canvas dataset ids are preserved as crate @ids
       const dsEntity = out['@graph'].find(
-        (e: Record<string, unknown>) => e['@id'] === '#dataset-0',
+        (e: Record<string, unknown>) => e['@id'] === '#ds-1',
       ) as Record<string, unknown>
       expect(dsEntity['dcat:landingPage']).toEqual({ '@id': 'https://example.com/sheets/ds-1' })
     })
@@ -200,7 +201,7 @@ describe('generateROCrate', () => {
       }
       const out = generateROCrate(dataNoSheet)
       const dsEntity = out['@graph'].find(
-        (e: Record<string, unknown>) => e['@id'] === '#dataset-0',
+        (e: Record<string, unknown>) => e['@id'] === '#ds-1',
       ) as Record<string, unknown>
       expect(dsEntity['dcat:landingPage']).toBeUndefined()
     })

--- a/src/utils/rocrate.ts
+++ b/src/utils/rocrate.ts
@@ -90,6 +90,14 @@ function generateId(prefix: string, index?: number): string {
 }
 
 /**
+ * Crate @id for a dataset. Preserves the canvas dataset id (like requirement
+ * ids) so task-level dataset links survive export → import roundtrips.
+ */
+function datasetCrateId(dataset: { id?: string }, index: number): string {
+  return dataset.id && /^[\w-]+$/.test(dataset.id) ? `#${dataset.id}` : generateId('dataset', index)
+}
+
+/**
  * Person identity for deduplication
  */
 interface PersonIdentity {
@@ -523,6 +531,12 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
   // Track emitted model URIs for deduplication
   const emittedModelUris = new Set<string>()
 
+  // Map canvas dataset ids to crate ids so steps can reference the datasets they use
+  const datasetCrateIds = new Map<string, string>()
+  data.dataAccess?.datasets?.forEach((dataset, index) => {
+    datasetCrateIds.set(dataset.id, datasetCrateId(dataset, index))
+  })
+
   // 4. User Expectations as P-Plan
   if (data.userExpectations?.requirements && data.userExpectations.requirements.length > 0) {
     const planId = generateId('user-plan')
@@ -580,11 +594,23 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
       if (req.feasibility && Object.keys(req.feasibility).length > 0) {
         stepEntity['aac:feasibility'] = req.feasibility
       }
+      // Collect prov:used references (datasets used by this task + model card)
+      const provUsedRefs: Array<{ '@id': string }> = []
+      // Task-level data access: embed the blob and reference linked datasets
+      if (req.dataAccess?.datasetLinks && req.dataAccess.datasetLinks.length > 0) {
+        stepEntity['aac:dataAccess'] = req.dataAccess
+        req.dataAccess.datasetLinks.forEach((link) => {
+          const crateId = datasetCrateIds.get(link.datasetId)
+          if (crateId) {
+            provUsedRefs.push({ '@id': crateId })
+          }
+        })
+      }
       // Emit SoftwareApplication entity for model card URI; link step to model via PROV
       if (req.feasibility?.modelCardUri) {
         const modelUri = req.feasibility.modelCardUri
         stepEntity['aac:model'] = { '@id': modelUri }
-        stepEntity['prov:used'] = { '@id': modelUri }
+        provUsedRefs.push({ '@id': modelUri })
         if (!emittedModelUris.has(modelUri)) {
           emittedModelUris.add(modelUri)
           const modelEntity: ROCrateEntity = {
@@ -598,6 +624,11 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
           }
           graph.push(modelEntity)
         }
+      }
+      if (provUsedRefs.length === 1) {
+        stepEntity['prov:used'] = provUsedRefs[0]
+      } else if (provUsedRefs.length > 1) {
+        stepEntity['prov:used'] = provUsedRefs
       }
       if (req.stakeholders && req.stakeholders.length > 0) {
         stepEntity['aac:stakeholders'] = req.stakeholders
@@ -823,7 +854,7 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
   // 6. Datasets (DCAT)
   if (data.dataAccess?.datasets && data.dataAccess.datasets.length > 0) {
     data.dataAccess.datasets.forEach((dataset, index) => {
-      const datasetId = generateId('dataset', index)
+      const datasetId = datasetCrateId(dataset, index)
       hasPart.push({ '@id': datasetId })
 
       const datasetEntity: ROCrateEntity = {

--- a/src/utils/rocrate.ts
+++ b/src/utils/rocrate.ts
@@ -90,11 +90,45 @@ function generateId(prefix: string, index?: number): string {
 }
 
 /**
- * Crate @id for a dataset. Preserves the canvas dataset id (like requirement
- * ids) so task-level dataset links survive export → import roundtrips.
+ * Crate @ids for all datasets, allocated up front. Preserves canvas dataset
+ * ids (like requirement ids) so task-level dataset links survive export →
+ * import roundtrips; ids that are not valid fragments or would duplicate an
+ * already-taken @id (another dataset, a step) get a unique #dataset-<n>
+ * fallback instead. byIndex drives entity emission; byCanvasId resolves links.
  */
-function datasetCrateId(dataset: { id?: string }, index: number): string {
-  return dataset.id && /^[\w-]+$/.test(dataset.id) ? `#${dataset.id}` : generateId('dataset', index)
+function buildDatasetCrateIds(data: CanvasData): {
+  byIndex: string[]
+  byCanvasId: Map<string, string>
+} {
+  const datasets = data.dataAccess?.datasets ?? []
+  const used = new Set<string>()
+  // Steps are emitted with these @ids (section 4); a dataset must never claim one
+  data.userExpectations?.requirements?.forEach((req, index) => {
+    used.add(req.id && /^[\w-]+$/.test(req.id) ? `#${req.id}` : generateId('requirement', index))
+  })
+
+  const byIndex: string[] = new Array(datasets.length)
+  const byCanvasId = new Map<string, string>()
+
+  // Preserve valid, unique canvas ids first so fallbacks can never displace them
+  datasets.forEach((dataset, index) => {
+    if (dataset.id && /^[\w-]+$/.test(dataset.id) && !used.has(`#${dataset.id}`)) {
+      byIndex[index] = `#${dataset.id}`
+      used.add(byIndex[index])
+    }
+  })
+  let fallback = 0
+  datasets.forEach((dataset, index) => {
+    if (byIndex[index] === undefined) {
+      while (used.has(generateId('dataset', fallback))) fallback++
+      byIndex[index] = generateId('dataset', fallback++)
+      used.add(byIndex[index])
+    }
+    if (!byCanvasId.has(dataset.id)) {
+      byCanvasId.set(dataset.id, byIndex[index])
+    }
+  })
+  return { byIndex, byCanvasId }
 }
 
 /**
@@ -531,11 +565,8 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
   // Track emitted model URIs for deduplication
   const emittedModelUris = new Set<string>()
 
-  // Map canvas dataset ids to crate ids so steps can reference the datasets they use
-  const datasetCrateIds = new Map<string, string>()
-  data.dataAccess?.datasets?.forEach((dataset, index) => {
-    datasetCrateIds.set(dataset.id, datasetCrateId(dataset, index))
-  })
+  // Crate ids for datasets, so steps can reference the datasets they use
+  const datasetCrateIds = buildDatasetCrateIds(data)
 
   // 4. User Expectations as P-Plan
   if (data.userExpectations?.requirements && data.userExpectations.requirements.length > 0) {
@@ -596,15 +627,19 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
       }
       // Collect prov:used references (datasets used by this task + model card)
       const provUsedRefs: Array<{ '@id': string }> = []
-      // Task-level data access: embed the blob and reference linked datasets
+      // Task-level data access: embed the blob and reference linked datasets.
+      // Link ids are rewritten to the crate ids so the blob can never disagree
+      // with the dataset @ids the importer derives ids from.
       if (req.dataAccess?.datasetLinks && req.dataAccess.datasetLinks.length > 0) {
-        stepEntity['aac:dataAccess'] = req.dataAccess
-        req.dataAccess.datasetLinks.forEach((link) => {
-          const crateId = datasetCrateIds.get(link.datasetId)
-          if (crateId) {
+        stepEntity['aac:dataAccess'] = {
+          ...req.dataAccess,
+          datasetLinks: req.dataAccess.datasetLinks.map((link) => {
+            const crateId = datasetCrateIds.byCanvasId.get(link.datasetId)
+            if (!crateId) return link // dangling link (deleted dataset): keep as-is
             provUsedRefs.push({ '@id': crateId })
-          }
-        })
+            return { ...link, datasetId: crateId.slice(1) }
+          }),
+        }
       }
       // Emit SoftwareApplication entity for model card URI; link step to model via PROV
       if (req.feasibility?.modelCardUri) {
@@ -854,7 +889,7 @@ export function generateROCrate(data: CanvasData, options?: GenerateROCrateOptio
   // 6. Datasets (DCAT)
   if (data.dataAccess?.datasets && data.dataAccess.datasets.length > 0) {
     data.dataAccess.datasets.forEach((dataset, index) => {
-      const datasetId = datasetCrateId(dataset, index)
+      const datasetId = datasetCrateIds.byIndex[index]
       hasPart.push({ '@id': datasetId })
 
       const datasetEntity: ROCrateEntity = {


### PR DESCRIPTION
Two additions from the framework-vs-standard discussion:

**Canvas Summary, essentials first.** Each block gains an inline strip with its essential fields, written straight into the existing canvas (same fields, same export). Strips auto-open while incomplete, collapse into an `essentials ✓` chip in the block header, and a banner tracks n/6 progress.

**Task-level data access.** Tasks appear in the Data Access tab (same mechanism as task-level feasibility) and link the datasets they use with agent actions (read / modify / process / generate). Linking a restricted or personal-data dataset to a frontier-model task raises an advisory DPA/GDPR flag, never blocking. Links survive RO-Crate export → import, and AGENTS.md gains a per-task permissions section.

Verified against the clinical de-identification scenario: an on-premise de-ID task over personal data raises no flag; a frontier-model task reading raw letters does.